### PR TITLE
Fix memory safety issue on pic-buf feature due to arithmetic overflow

### DIFF
--- a/crates/rav1d-disjoint-mut/src/lib.rs
+++ b/crates/rav1d-disjoint-mut/src/lib.rs
@@ -1692,7 +1692,7 @@ mod pic_buf {
         ///
         /// # Panics
         ///
-        /// Panics if `align_offset + usable_len > vec.len()`.
+        /// Panics if `align_offset + usable_len` overflows or exceeds `vec.len()`.
         pub fn from_vec_aligned(vec: Vec<u8>, alignment: usize, usable_len: usize) -> Self {
             if usable_len == 0 {
                 return Self {
@@ -1702,8 +1702,11 @@ mod pic_buf {
                 };
             }
             let align_offset = vec.as_ptr().align_offset(alignment);
+            let region_end = align_offset.checked_add(usable_len).unwrap_or_else(|| {
+                panic!("PicBuf: aligned region ({align_offset} + {usable_len}) overflows usize")
+            });
             assert!(
-                align_offset + usable_len <= vec.len(),
+                region_end <= vec.len(),
                 "PicBuf: aligned region ({} + {}) exceeds Vec length ({})",
                 align_offset,
                 usable_len,


### PR DESCRIPTION
Fix `rav1d-disjoint-mut` allowing out-of-bounds reads/writes.

Full reproducer to trigger UB under miri in safe code, more verbose than the regression test included in the PR:

```rust
#[cfg(all(feature = "pic-buf", not(debug_assertions)))]
#[test]
fn pic_buf_len_overflow_allows_safe_oob_mut_borrow() {
    use rav1d_disjoint_mut::PicBuf;

    // Issue: PicBuf::from_vec_aligned validates `align_offset + usable_len <= vec.len()`
    // using unchecked addition. In release builds, a huge `usable_len` can wrap the
    // sum back below `vec.len()`, so the safe constructor records a usable slice
    // length much larger than the allocation. DisjointMut then trusts that length
    // in its safe `index_mut` API and performs raw pointer arithmetic past the Vec.
    // Miri reports UB when `index_mut` creates a mutable reference outside the
    // allocation.
    let mut chosen = None;

    for power in 1..=16 {
        let alignment = 1usize << power;
        let vec = vec![0u8; alignment * 2];
        let align_offset = vec.as_ptr().align_offset(alignment);

        if align_offset > 0 && align_offset < alignment {
            chosen = Some((vec, alignment, align_offset));
            break;
        }
    }

    let (vec, alignment, align_offset) =
        chosen.expect("expected at least one allocation not to satisfy a larger alignment");
    let real_len = vec.len();
    let usable_len = usize::MAX.wrapping_sub(align_offset).wrapping_add(1);

    let pic = PicBuf::from_vec_aligned(vec, alignment, usable_len);
    let dm = DisjointMut::new(pic);

    let first_oob_index = real_len - align_offset;
    let mut byte = dm.index_mut(first_oob_index);
    *byte = 1;
}
```

The issue was discovered by GPT-5.5 xhigh