### PR TITLE
fix: safe parser arithmetic and conservative defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,10 @@ opt-level = 1
 
 [profile.release]
 codegen-units = 1
-panic = "abort"
+# panic = "abort" is intentionally NOT set here: a parser panic on a
+# malformed AV1 bitstream must NOT terminate the host process. Library
+# consumers (image servers, browsers, decoders) need the ability to
+# catch_unwind around decode and recover.
 lto = "fat"
 strip = false
 debug = "line-tables-only"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,11 @@ impl Default for Rav1dSettings {
             apply_grain: true,
             operating_point: 0,
             all_layers: true,
-            frame_size_limit: 0,
+            // Safe default: cap at 8K UHD (~35MP). Setting 0 means "unlimited",
+            // which lets a malicious SequenceHeader declaring 65536x65536 trigger
+            // multi-GB allocation amplification on 64-bit hosts. Callers that
+            // really need larger frames must opt in explicitly.
+            frame_size_limit: 8192 * 4320,
             allocator: Default::default(),
             logger: Some(Rav1dLogger::default()),
             strict_std_compliance: false,

--- a/src/msac.rs
+++ b/src/msac.rs
@@ -403,7 +403,11 @@ fn ctx_norm(s: &mut MsacContext, dif: EcWin, rng: c_uint) {
     debug_assert!(rng <= 65535);
     s.dif = dif << d;
     s.rng = rng << d;
-    s.cnt = cnt - d;
+    // At EOB, `cnt - d` legitimately wraps negative; the unsigned compare
+    // below detects this and triggers a refill. With debug overflow checks
+    // (and especially with `panic = abort` in dev), the plain subtraction
+    // panics on every EOB. Use `wrapping_sub` to match dav1d's C semantics.
+    s.cnt = cnt.wrapping_sub(d);
     // unsigned compare avoids redundant refills at eob
     if (cnt as u32) < (d as u32) {
         ctx_refill(s);

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -2232,7 +2232,9 @@ fn parse_obus(
         data.slice_in_place(gb.byte_pos()..);
         data.slice_in_place(..gb.remaining_len());
         // Ensure tile groups are in order and sane; see 6.10.1.
-        if hdr.start > hdr.end || hdr.start != state.n_tiles {
+        let frame_hdr = state.frame_hdr.as_ref().ok_or(EINVAL)?;
+        let max_tiles = frame_hdr.tiling.cols as c_int * frame_hdr.tiling.rows as c_int;
+        if hdr.start > hdr.end || hdr.start != state.n_tiles || hdr.end >= max_tiles {
             state.tiles.clear();
             state.n_tiles = 0;
             return Err(EINVAL);
@@ -2240,6 +2242,10 @@ fn parse_obus(
         if state.tiles.try_reserve_exact(1).is_err() {
             return Err(EINVAL);
         }
+        // Bound check above guarantees `1 + hdr.end - hdr.start <= max_tiles`
+        // (with `max_tiles <= 64*64 = 4096`), so this addition cannot overflow
+        // an i32 nor exceed the per-frame tile cap that downstream code
+        // assumes (e.g. the `state.n_tiles == cols*rows` check in caller).
         state.n_tiles += 1 + hdr.end - hdr.start;
         state.tiles.push(Rav1dTileGroup {
             data: Rav1dData {


### PR DESCRIPTION
Hardening based on internal security audit (`/home/lilith/work/feedback/security-audit-2026-05-06/rav1d-safe.md`). Addresses all 4 HIGH findings.

## Changes

- **H1** (6e69449): Default `frame_size_limit` to 8K UHD instead of `0` (unlimited). Was multi-GB allocation amplification from a SequenceHeader declaring 65536×65536.
- **H2** (c09bca7): Drop `panic = "abort"` from release profile. Was converting every parser panic into a process kill.
- **H3** (e945a67): `ctx_norm` uses `wrapping_sub` to match dav1d EOB semantics. Was underflowing in debug-with-overflow-checks (debug+abort = process kill on EOB).
- **H4** (3baac47): Bound `n_tiles` by `tiling.cols*rows` in `parse_tile_grp`. Was unbounded i32 increment.

## Tests

`cargo test --all-targets` and `cargo test --doc` pass on the fix branch.

## Deferred

MEDIUM and LOW findings deferred to follow-up.