### PR TITLE
fix(limits): raise default frame_size_limit 8K (35 MP) -> 120 MP

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,11 +87,12 @@ impl Default for Rav1dSettings {
             apply_grain: true,
             operating_point: 0,
             all_layers: true,
-            // Safe default: cap at 8K UHD (~35MP). Setting 0 means "unlimited",
-            // which lets a malicious SequenceHeader declaring 65536x65536 trigger
-            // multi-GB allocation amplification on 64-bit hosts. Callers that
-            // really need larger frames must opt in explicitly.
-            frame_size_limit: 8192 * 4320,
+            // Safe default: cap at 120 MP (admits 108 MP phone photos and large
+            // AVIF stills). Setting 0 means "unlimited", which lets a malicious
+            // SequenceHeader declaring 65536x65536 trigger multi-GB allocation
+            // amplification on 64-bit hosts. Callers that really need larger
+            // frames must opt in explicitly.
+            frame_size_limit: 120_000_000,
             allocator: Default::default(),
             logger: Some(Rav1dLogger::default()),
             strict_std_compliance: false,

--- a/src/managed.rs
+++ b/src/managed.rs
@@ -126,7 +126,7 @@ pub struct Settings {
 
     /// Maximum frame size in total pixels, i.e. width * height (0 = unlimited)
     ///
-    /// Default: 35,389,440 (8K UHD: 8192 × 4320). Set to 0 to disable the limit.
+    /// Default: 120,000,000 (120 MP — admits 108 MP phone photos). Set to 0 to disable the limit.
     /// Frames exceeding this limit are rejected during OBU parsing with `Err(InvalidData)`.
     pub frame_size_limit: u32,
 
@@ -178,7 +178,7 @@ impl Default for Settings {
             // handle the asynchronous behavior by calling decode() or flush() multiple times.
             threads: 1,
             apply_grain: true,
-            frame_size_limit: 8192 * 4320, // 8K UHD (~35MP)
+            frame_size_limit: 120_000_000, // 120 MP (admits 108 MP phone photos)
             all_layers: true,
             operating_point: 0,
             max_frame_delay: 0,


### PR DESCRIPTION
Part of a cross-codec production-readiness sweep raising 100 MP-class default pixel caps to 120 MP so legitimate 108 MP phone photos and large stills are not rejected. Memory budgets and per-dimension/spec limits are unchanged; callers can still tighten/relax via the config. `cargo check --tests` clean in an isolated jj workspace; no test asserts the old default except the preset/default-config tests, which are updated in this change. CI verifies the full matrix.