### PR TITLE
Implement DisjointMut creation from a mutable slice

### DIFF
--- a/crates/rav1d-disjoint-mut/src/lib.rs
+++ b/crates/rav1d-disjoint-mut/src/lib.rs
@@ -323,6 +323,7 @@ mod sealed {
     pub trait Sealed {}
 
     impl<V: Copy> Sealed for Vec<V> {}
+    impl<V: Copy> Sealed for &mut [V] {}
     impl<V: Copy, const N: usize> Sealed for [V; N] {}
     impl<V: Copy> Sealed for [V] {}
     impl<V: Copy> Sealed for Box<[V]> {}
@@ -1539,6 +1540,32 @@ unsafe impl<V: Copy> AsMutPtr for Vec<V> {
 
     fn len(&self) -> usize {
         self.len()
+    }
+}
+
+/// SAFETY: Copies the stored mutable slice reference as a raw slice pointer
+/// without materializing a reference to the full slice. The data is borrowed
+/// from the caller, so creating `&[V]` or `&mut [V]` for metadata lookup would
+/// conflict with outstanding guards under Stacked Borrows.
+unsafe impl<V: Copy> AsMutPtr for &mut [V] {
+    type Target = V;
+
+    unsafe fn as_mut_slice(ptr: *mut Self) -> *mut [Self::Target] {
+        // SAFETY: `&mut [V]` and `*mut [V]` have the same pointer layout.
+        // Reading the raw pointer value avoids reborrowing the full slice.
+        unsafe { ptr.cast::<*mut [V]>().read() }
+    }
+
+    unsafe fn as_mut_ptr(ptr: *mut Self) -> *mut V {
+        // SAFETY: Same as `as_mut_slice`; casting the raw slice pointer to its
+        // data pointer does not create an intermediate reference.
+        unsafe { Self::as_mut_slice(ptr).cast() }
+    }
+
+    fn len(&self) -> usize {
+        // SAFETY: `self` is a reference to the stored slice reference, not to
+        // the slice data. Copy the raw slice pointer value and read its metadata.
+        unsafe { ptr::from_ref(self).cast::<*const [V]>().read().len() }
     }
 }
 

--- a/crates/rav1d-disjoint-mut/tests/soundness.rs
+++ b/crates/rav1d-disjoint-mut/tests/soundness.rs
@@ -396,6 +396,31 @@ fn test_zerocopy_cast_disjoint() {
     assert_eq!(g2[0], [5, 6, 7, 8]);
 }
 
+/// Test: borrowed mutable slice backing with zerocopy typed guards.
+///
+/// This exercises the borrowed-slice `as_mut_slice` metadata path while
+/// typed mutable guards are alive.
+#[cfg(feature = "zerocopy")]
+#[test]
+fn test_borrowed_slice_zerocopy_cast_disjoint() {
+    let mut buf = [0u8; 16];
+    let dm = DisjointMut::new(&mut buf[..]);
+
+    let mut g1 = dm.mut_slice_as::<_, [u8; 4]>(0..2);
+    let mut g2 = dm.mut_slice_as::<_, [u8; 4]>(2..4);
+    assert_eq!(dm.len(), 16);
+
+    g1[0] = [1, 2, 3, 4];
+    g2[1] = [13, 14, 15, 16];
+    assert_eq!(g1[0], [1, 2, 3, 4]);
+    assert_eq!(g2[1], [13, 14, 15, 16]);
+
+    drop((g1, g2));
+    drop(dm);
+    assert_eq!(buf[0..4], [1, 2, 3, 4]);
+    assert_eq!(buf[12..16], [13, 14, 15, 16]);
+}
+
 /// Test: More than 64 concurrent borrows spill to overflow Vec without panicking.
 #[test]
 fn test_overflow_beyond_64_borrows() {

--- a/crates/rav1d-disjoint-mut/tests/soundness.rs
+++ b/crates/rav1d-disjoint-mut/tests/soundness.rs
@@ -285,6 +285,72 @@ fn test_concurrent_disjoint_box_slice() {
     }
 }
 
+/// Test: borrowed mutable slice backing.
+#[test]
+fn test_borrowed_slice_two_disjoint_mut_guards() {
+    let mut buf = [0u8; 64];
+    let mutable_slice = &mut buf[..];
+    let dm = DisjointMut::new(mutable_slice);
+    let mut g1 = dm.index_mut(0..32);
+    let mut g2 = dm.index_mut(32..64);
+    // mutable_slice[0] = 1; // can't do this while guards are alive
+    g1[0] = 1;
+    g2[0] = 2;
+    assert_eq!(g1[0], 1);
+    assert_eq!(g2[0], 2);
+    drop((g1, g2));
+    drop(dm);
+    assert_eq!(buf[0], 1);
+    assert_eq!(buf[32], 2);
+}
+
+/// Test: borrowed mutable slice backing with immutable and mutable guards.
+#[test]
+fn test_borrowed_slice_immut_and_mut_disjoint() {
+    let mut buf = [0u8; 64];
+    let mutable_slice = &mut buf[..];
+    let dm = DisjointMut::new(mutable_slice);
+    let g1 = dm.index(0..32);
+    let mut g2 = dm.index_mut(32..64);
+    // mutable_slice[0] = 42; // can't do this while guards are alive
+    g2[0] = 42;
+    assert_eq!(g1[0], 0);
+    assert_eq!(g2[0], 42);
+}
+
+/// Test: borrowed mutable slice can be shared across scoped threads.
+#[test]
+fn test_borrowed_slice_scoped_threads() {
+    let mut buf = [0u8; 100];
+    let mutable_slice = &mut buf[..];
+    let dm = DisjointMut::new(mutable_slice);
+
+    thread::scope(|scope| {
+        let dm = &dm;
+
+        let t1 = scope.spawn(move || {
+            let mut guard = dm.index_mut(0..50);
+            for i in 0..50 {
+                guard[i] = 1;
+            }
+        });
+
+        let t2 = scope.spawn(move || {
+            let mut guard = dm.index_mut(50..100);
+            for i in 0..50 {
+                guard[i] = 2;
+            }
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+    });
+
+    drop(dm);
+    assert_eq!(buf[49], 1);
+    assert_eq!(buf[50], 2);
+}
+
 /// Test: concurrent disjoint access with array backing.
 #[test]
 fn test_concurrent_disjoint_array() {


### PR DESCRIPTION
Turns out this is possible under both Stacked Borrows and Tree Borrows. This _feels_ like crimes against provenance, but `miri` says this is totally legit. 

Under Stacked Borrows, “a reference exists somewhere” is not by itself UB. The problem would be accessing/reborrowing the full slice through that `&mut [V]` while `&mut` guards to subranges exist. That would retag the whole slice and invalidate the chunk borrows. So we carefully avoid materializing `&[V]`/`&mut [V]` for the full slice by using raw pointers in the creation instead.

Provenance of the included unit test looks like this:

1. `DisjointMut::new(&mut buf[..])` consumes the unique full-slice borrow.
2. The stored `&mut [V]` acts as the provenance source.
3. `index_mut(0..32)` creates a child `&mut` for only `0..32`.
4. `index_mut(32..64)` creates another child `&mut` for only `32..64`.
5. The original full-slice `&mut` remains dormant until those children are gone.

This is also (roughly) how [`slice::split_at_mut()`](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.split_at_mut) in the standard library deals with provenance, but we have to go to slightly greater lengths to avoid retagging.