### PR TITLE
fix(tile-threading): stop reserving inter-row gaps in the strided block guard

### DIFF
--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -84,11 +84,17 @@ use crate::include::common::bitdepth::BitDepth;
 
 /// Execute a closure with mutable byte access to a w×h pixel block.
 ///
-/// In single-threaded mode: zero-copy via `narrow_guard_mut`.
-/// In multi-threaded mode: copies to/from a compact buffer with per-row guards.
+/// The closure receives `(bytes, offset, stride)` — a mutable byte slice, the
+/// BYTE offset to the first pixel, and the byte stride between rows.
 ///
-/// The closure receives `(bytes, offset, stride)` — a mutable byte slice,
-/// the byte offset to the first pixel, and the byte stride between rows.
+/// This is a closure-shaped front end for [`WithOffset::block_mut`], which owns
+/// the single-threaded-vs-tile-threaded policy. The two exist because call sites
+/// come in two shapes — a closure suits the x86-64 and generic dispatchers, an
+/// RAII guard suits the aarch64/wasm ones that need the slice to outlive a
+/// borrow — but there must be exactly ONE implementation of the policy behind
+/// them. When there were two, the aarch64 half silently kept reserving inter-row
+/// gaps long after the x86-64 half stopped, which is the bug this whole change
+/// exists to fix.
 #[inline]
 pub fn with_pixel_guard_mut<BD: BitDepth, R>(
     pic: &crate::src::with_offset::WithOffset<&Rav1dPictureDataComponent>,
@@ -96,21 +102,17 @@ pub fn with_pixel_guard_mut<BD: BitDepth, R>(
     h: usize,
     f: impl FnOnce(&mut [u8], usize, isize) -> R,
 ) -> R {
-    use crate::src::strided::Strided as _;
-    let pixel_size = core::mem::size_of::<BD::Pixel>();
-    if tile_threading_active() {
-        let (mut buf, byte_stride) = pic.compact_read_per_row::<BD>(w, h);
-        let result = f(&mut buf, 0, byte_stride as isize);
-        pic.compact_write_back_per_row::<BD>(w, h, &buf);
-        recycle_compact_scratch(buf);
-        result
-    } else {
-        let (mut guard, base) = pic.narrow_guard_mut::<BD>(w, h);
-        let bytes = guard.as_mut_bytes();
-        let offset = base * pixel_size;
-        let stride = pic.stride();
-        f(bytes, offset, stride)
-    }
+    let mut block = pic.block_mut::<BD>(w, h);
+    // `BlockMut::base()` is a PIXEL index — 0 for a compact block, and the
+    // last row's index for a direct block on a negative-stride picture. This
+    // closure's contract is a BYTE offset, so the scaling happens here rather
+    // than inside `BlockMut`, whose own users index the byte slice directly.
+    let offset = block.base() * core::mem::size_of::<BD::Pixel>();
+    let stride = block.byte_stride();
+    // `block` is dropped at the end of this expression, i.e. after `f` has run:
+    // a compact block therefore writes back before the caller observes `R`,
+    // exactly as the previous open-coded version did.
+    f(block.as_mut_bytes(), offset, stride)
 }
 
 /// Execute a closure with read-only byte access to a w×h pixel block.

--- a/include/dav1d/picture.rs
+++ b/include/dav1d/picture.rs
@@ -767,6 +767,65 @@ impl<'a> Rav1dPictureDataComponentOffset<'a> {
         self.narrow_guard_mut::<BD>(w, h)
     }
 
+    /// A mutable w×h pixel block that is safe to write while OTHER threads
+    /// write other blocks on the same rows.
+    ///
+    /// # Why this exists
+    ///
+    /// [`Self::strided_slice_mut`] reserves ONE contiguous range covering the
+    /// whole strided span, `(h - 1) * stride + w` pixels — everything from the
+    /// block's first pixel to its last, INCLUDING the inter-row gaps, which
+    /// belong to other blocks. That is correct single-threaded and wrong under
+    /// tile threading: AV1 tiles partition a frame by columns, so two tile
+    /// workers routinely write the SAME rows at different columns. The second
+    /// one lands in the first one's reserved gap and `DisjointMut` panics —
+    /// a false positive, since the two writes are genuinely disjoint.
+    ///
+    /// Concretely, on a 3840-wide frame a 16×16 block reserves 57,616 bytes in
+    /// order to write 256, and a neighbouring 16-byte intra-prediction write
+    /// anywhere in those rows trips it. (zenavif#30; the same defect class the
+    /// loopfilter and `ipred` compact paths already fixed for themselves.)
+    ///
+    /// # What it does
+    ///
+    /// * Tile threading OFF — hands back exactly what `strided_slice_mut`
+    ///   does: one contiguous guard, the picture's own stride, no copying.
+    ///   Byte-identical behavior and identical cost to before.
+    /// * Tile threading ON — copies the block into a compact `w × h` scratch
+    ///   buffer through PER-ROW guards (each reserving only the `w` pixels
+    ///   actually touched), lets the caller work on that, and writes it back
+    ///   per row on drop. No gap is ever reserved, so disjoint neighbours
+    ///   cannot collide.
+    ///
+    /// Callers must take the stride from [`BlockMut::byte_stride`] rather than
+    /// from the picture, because the compact buffer has its own stride.
+    #[cfg_attr(debug_assertions, track_caller)]
+    pub fn block_mut<BD: BitDepth>(&self, w: usize, h: usize) -> BlockMut<'a, BD> {
+        if tile_threading_active() {
+            let (buf, byte_stride) = self.compact_read_per_row::<BD>(w, h);
+            BlockMut {
+                storage: BlockMutStorage::Compact { buf },
+                dst: *self,
+                w,
+                h,
+                base: 0,
+                byte_stride: byte_stride as isize,
+            }
+        } else {
+            use crate::src::strided::Strided as _;
+            let byte_stride = self.stride();
+            let (guard, base) = self.narrow_guard_mut::<BD>(w, h);
+            BlockMut {
+                storage: BlockMutStorage::Direct { guard },
+                dst: *self,
+                w,
+                h,
+                base,
+                byte_stride,
+            }
+        }
+    }
+
     /// Create a tracked immutable guard covering a strided w×h pixel region.
     #[inline]
     #[cfg_attr(debug_assertions, track_caller)]
@@ -1627,3 +1686,72 @@ impl Rav1dPicAllocator {
     }
 }
 pub type PicOffset<'a> = Rav1dPictureDataComponentOffset<'a>;
+
+/// Backing storage for [`BlockMut`] — see [`WithOffset::block_mut`].
+enum BlockMutStorage<'a, BD: BitDepth> {
+    /// Tile threading off: the picture's own memory, one contiguous guard.
+    Direct {
+        guard: DisjointMutGuard<'a, Rav1dPictureDataComponentInner, [BD::Pixel]>,
+    },
+    /// Tile threading on: a detached compact copy, written back on drop.
+    Compact { buf: Vec<u8> },
+}
+
+/// A writable w×h pixel block. Obtain one with [`WithOffset::block_mut`], which
+/// documents why the compact variant exists.
+///
+/// On drop, a compact block is written back to the picture through per-row
+/// guards. A direct block has nothing to do — the caller wrote the picture in
+/// place.
+pub struct BlockMut<'a, BD: BitDepth> {
+    storage: BlockMutStorage<'a, BD>,
+    dst: WithOffset<&'a Rav1dPictureDataComponent>,
+    w: usize,
+    h: usize,
+    base: usize,
+    byte_stride: isize,
+}
+
+impl<'a, BD: BitDepth> BlockMut<'a, BD> {
+    /// Byte stride of the buffer returned by [`Self::as_mut_bytes`].
+    ///
+    /// NOT necessarily the picture's stride: a compact block is tightly packed
+    /// at `w * size_of::<BD::Pixel>()`. Always positive in the compact case;
+    /// may be negative in the direct case, exactly as the picture's is.
+    #[inline]
+    pub fn byte_stride(&self) -> isize {
+        self.byte_stride
+    }
+
+    /// Index within [`Self::as_mut_bytes`] of the block's first pixel.
+    ///
+    /// Zero for a compact block; for a direct block with negative stride it is
+    /// the last row's offset, matching `strided_slice_mut`'s second return value.
+    #[inline]
+    pub fn base(&self) -> usize {
+        self.base
+    }
+
+    /// The writable bytes.
+    #[inline]
+    pub fn as_mut_bytes(&mut self) -> &mut [u8] {
+        match &mut self.storage {
+            BlockMutStorage::Direct { guard } => guard.as_mut_bytes(),
+            BlockMutStorage::Compact { buf } => buf.as_mut_slice(),
+        }
+    }
+}
+
+impl<BD: BitDepth> Drop for BlockMut<'_, BD> {
+    fn drop(&mut self) {
+        if let BlockMutStorage::Compact { buf } = &mut self.storage {
+            // Unconditional per-row write-back rather than the loopfilter's
+            // diff variant: an inverse transform adds residual across the whole
+            // block, so a diff would compare every byte only to discover that
+            // every byte changed. Per-row is what keeps the reservations narrow.
+            self.dst
+                .compact_write_back_per_row::<BD>(self.w, self.h, buf);
+            recycle_compact_scratch(core::mem::take(buf));
+        }
+    }
+}

--- a/src/cdef.rs
+++ b/src/cdef.rs
@@ -485,7 +485,9 @@ fn padding<BD: BitDepth>(
         // Same exact-window discipline as the top loop above: never guard the
         // skipped left-padding columns.
         let bottom = match bottom.data {
-            PicOrBuf::Pic(pic) => &*pic.slice::<BD, _>((bottom.offset + x_start.., ..x_end - x_start)),
+            PicOrBuf::Pic(pic) => {
+                &*pic.slice::<BD, _>((bottom.offset + x_start.., ..x_end - x_start))
+            }
             PicOrBuf::Buf(buf) => &*buf.slice_as((bottom.offset + x_start.., ..x_end - x_start)),
         };
         for x in x_start..x_end {

--- a/src/obu.rs
+++ b/src/obu.rs
@@ -1979,7 +1979,7 @@ fn parse_frame_hdr(
         size = parse_frame_size(
             state,
             seqhdr,
-            Some(&refidx).filter(|_| use_ref),
+            use_ref.then_some(&refidx),
             frame_size_override,
             gb,
         )?;

--- a/src/safe_simd/cdef_arm.rs
+++ b/src/safe_simd/cdef_arm.rs
@@ -29,6 +29,8 @@ use crate::src::pic_or_buf::PicOrBuf;
 use crate::src::strided::Strided as _;
 use crate::src::tables::dav1d_cdef_directions;
 use crate::src::with_offset::WithOffset;
+// Used only by the `extern "C"` dispatch wrappers, which are asm-gated.
+#[cfg_attr(not(all(feature = "asm", target_arch = "aarch64")), allow(dead_code))]
 #[allow(non_camel_case_types)]
 type ptrdiff_t = isize;
 

--- a/src/safe_simd/cdef_wasm.rs
+++ b/src/safe_simd/cdef_wasm.rs
@@ -75,7 +75,6 @@ fn cdef_filter_block_simd_8bpc(
     tmp: &[u16],
     tmp_offset: usize,
     dst: PicOffset,
-    stride: isize,
     w: usize,
     h: usize,
     dir: usize,
@@ -88,8 +87,17 @@ fn cdef_filter_block_simd_8bpc(
 
     let zero = i16x8_splat(0);
 
-    // Single guard for entire output region
-    let (mut p_guard, p_base) = dst.strided_slice_mut::<BitDepth8>(w, h);
+    // Tile-threading-safe block view: contiguous when threading is off, a
+    // compact per-row copy when it is on. See `WithOffset::block_mut`.
+    // Taps are read from the padded `tmp` copy, so only the w×h output region
+    // is touched here.
+    let mut block = dst.block_mut::<BitDepth8>(w, h);
+    // The block has its own stride (compact when tile threading is on), so it
+    // supersedes the caller-supplied picture stride. 8bpc: 1 byte per pixel,
+    // so the byte stride is the pixel stride.
+    let stride = block.byte_stride();
+    let p_base = block.base();
+    let p_guard = block.as_mut_bytes();
 
     if pri_strength != 0 {
         let pri_tap = 4 - (pri_strength & 1);
@@ -275,7 +283,6 @@ fn cdef_filter_block_simd_16bpc(
     tmp: &[u16],
     tmp_offset: usize,
     dst: PicOffset,
-    stride: isize,
     w: usize,
     h: usize,
     dir: usize,
@@ -291,8 +298,18 @@ fn cdef_filter_block_simd_16bpc(
     let bd_max = i16x8_splat(bitdepth_max as i16);
     let bitdepth_min_8 = ((bitdepth_max + 1) as u32).ilog2() as c_int - 8;
 
-    // Single guard for entire output region
-    let (mut p_guard, p_base) = dst.strided_slice_mut::<BitDepth16>(w, h);
+    // Tile-threading-safe block view: contiguous when threading is off, a
+    // compact per-row copy when it is on. See `WithOffset::block_mut`.
+    // Taps are read from the padded `tmp` copy, so only the w×h output region
+    // is touched here.
+    let mut block = dst.block_mut::<BitDepth16>(w, h);
+    // The block has its own stride (compact when tile threading is on), so it
+    // supersedes the caller-supplied picture stride. `p_guard` is indexed in
+    // pixels, so halve the byte stride.
+    let stride = block.byte_stride() / 2;
+    let p_base = block.base();
+    let p_guard: &mut [u16] = zerocopy::FromBytes::mut_from_bytes(block.as_mut_bytes())
+        .expect("dst alignment/size mismatch for u16 reinterpretation");
 
     if pri_strength != 0 {
         let pri_tap = 4 - (pri_strength >> bitdepth_min_8 & 1);
@@ -475,6 +492,8 @@ fn cdef_filter_8x8_8bpc_wasm_inner(
     padding_8bpc(&mut tmp, dst, left, top, bottom, 8, 8, edges);
 
     let tmp_offset = 2 * TMP_STRIDE + 2;
+    // Still needed by the scalar fallback below, which writes through the
+    // picture's own stride.
     let stride = dst.pixel_stride::<BitDepth8>();
 
     if let Some(token) = crate::src::cpu::summon_wasm128() {
@@ -483,7 +502,6 @@ fn cdef_filter_8x8_8bpc_wasm_inner(
             &tmp,
             tmp_offset,
             dst,
-            stride,
             8,
             8,
             dir as usize,
@@ -525,6 +543,8 @@ fn cdef_filter_4x8_8bpc_wasm_inner(
     padding_8bpc(&mut tmp, dst, left, top, bottom, 4, 8, edges);
 
     let tmp_offset = 2 * TMP_STRIDE + 2;
+    // Still needed by the scalar fallback below, which writes through the
+    // picture's own stride.
     let stride = dst.pixel_stride::<BitDepth8>();
 
     if let Some(token) = crate::src::cpu::summon_wasm128() {
@@ -533,7 +553,6 @@ fn cdef_filter_4x8_8bpc_wasm_inner(
             &tmp,
             tmp_offset,
             dst,
-            stride,
             4,
             8,
             dir as usize,
@@ -575,6 +594,8 @@ fn cdef_filter_4x4_8bpc_wasm_inner(
     padding_8bpc(&mut tmp, dst, left, top, bottom, 4, 4, edges);
 
     let tmp_offset = 2 * TMP_STRIDE + 2;
+    // Still needed by the scalar fallback below, which writes through the
+    // picture's own stride.
     let stride = dst.pixel_stride::<BitDepth8>();
 
     if let Some(token) = crate::src::cpu::summon_wasm128() {
@@ -583,7 +604,6 @@ fn cdef_filter_4x4_8bpc_wasm_inner(
             &tmp,
             tmp_offset,
             dst,
-            stride,
             4,
             4,
             dir as usize,
@@ -626,6 +646,8 @@ fn cdef_filter_8x8_16bpc_wasm_inner(
     padding_16bpc(&mut tmp, dst, left, top, bottom, 8, 8, edges, bitdepth_max);
 
     let tmp_offset = 2 * TMP_STRIDE + 2;
+    // Still needed by the scalar fallback below, which writes through the
+    // picture's own stride.
     let stride = dst.pixel_stride::<BitDepth16>();
 
     if let Some(token) = crate::src::cpu::summon_wasm128() {
@@ -634,7 +656,6 @@ fn cdef_filter_8x8_16bpc_wasm_inner(
             &tmp,
             tmp_offset,
             dst,
-            stride,
             8,
             8,
             dir as usize,
@@ -679,6 +700,8 @@ fn cdef_filter_4x8_16bpc_wasm_inner(
     padding_16bpc(&mut tmp, dst, left, top, bottom, 4, 8, edges, bitdepth_max);
 
     let tmp_offset = 2 * TMP_STRIDE + 2;
+    // Still needed by the scalar fallback below, which writes through the
+    // picture's own stride.
     let stride = dst.pixel_stride::<BitDepth16>();
 
     if let Some(token) = crate::src::cpu::summon_wasm128() {
@@ -687,7 +710,6 @@ fn cdef_filter_4x8_16bpc_wasm_inner(
             &tmp,
             tmp_offset,
             dst,
-            stride,
             4,
             8,
             dir as usize,
@@ -732,6 +754,8 @@ fn cdef_filter_4x4_16bpc_wasm_inner(
     padding_16bpc(&mut tmp, dst, left, top, bottom, 4, 4, edges, bitdepth_max);
 
     let tmp_offset = 2 * TMP_STRIDE + 2;
+    // Still needed by the scalar fallback below, which writes through the
+    // picture's own stride.
     let stride = dst.pixel_stride::<BitDepth16>();
 
     if let Some(token) = crate::src::cpu::summon_wasm128() {
@@ -740,7 +764,6 @@ fn cdef_filter_4x4_16bpc_wasm_inner(
             &tmp,
             tmp_offset,
             dst,
-            stride,
             4,
             4,
             dir as usize,

--- a/src/safe_simd/filmgrain_arm.rs
+++ b/src/safe_simd/filmgrain_arm.rs
@@ -21,14 +21,34 @@ use std::cmp;
 use std::ffi::c_int;
 use std::ffi::c_uint;
 
+// Used only by the `extern "C"` dispatch wrappers, which are asm-gated.
+#[cfg_attr(not(all(feature = "asm", target_arch = "aarch64")), allow(dead_code))]
 #[allow(non_camel_case_types)]
 type intptr_t = isize;
+#[cfg_attr(not(all(feature = "asm", target_arch = "aarch64")), allow(dead_code))]
 #[allow(non_camel_case_types)]
 type ptrdiff_t = isize;
 
+#[cfg_attr(
+    not(all(feature = "asm", target_arch = "aarch64")),
+    allow(unused_imports)
+)]
 use crate::include::common::bitdepth::{DynEntry, DynPixel, DynScaling};
-use crate::include::dav1d::headers::{Dav1dFilmGrainData, Rav1dFilmGrainData};
+#[cfg_attr(
+    not(all(feature = "asm", target_arch = "aarch64")),
+    allow(unused_imports)
+)]
+use crate::include::dav1d::headers::Dav1dFilmGrainData;
+use crate::include::dav1d::headers::Rav1dFilmGrainData;
+#[cfg_attr(
+    not(all(feature = "asm", target_arch = "aarch64")),
+    allow(unused_imports)
+)]
 use crate::include::dav1d::picture::PicOffset;
+#[cfg_attr(
+    not(all(feature = "asm", target_arch = "aarch64")),
+    allow(unused_imports)
+)]
 use crate::src::ffi_safe::FFISafe;
 use crate::src::filmgrain::{FG_BLOCK_SIZE, GRAIN_HEIGHT, GRAIN_WIDTH};
 use crate::src::internal::GrainLut;

--- a/src/safe_simd/itx_arm.rs
+++ b/src/safe_simd/itx_arm.rs
@@ -8407,11 +8407,15 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
 
             // Only 4x4 8bpc transforms are ported to NEON so far
             if w == 4 && h == 4 && BD::BPC == BPC::BPC8 {
-                let byte_stride_i = dst.stride();
                 let bd_c = bd.into_c();
 
-                let (mut guard, base) = dst.strided_slice_mut::<BD>(w, h);
-                let dst_u8: &mut [u8] = guard.as_mut_bytes();
+                // Tile-threading-safe block view: contiguous when threading is
+                // off, a compact per-row copy when it is on. See
+                // `WithOffset::block_mut`.
+                let mut block = dst.block_mut::<BD>(w, h);
+                let byte_stride_i = block.byte_stride();
+                let base = block.base();
+                let dst_u8: &mut [u8] = block.as_mut_bytes();
                 let coeff_i16: &mut [i16] =
                     zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                         .expect("coeff alignment/size mismatch for i16 reinterpretation");
@@ -8583,11 +8587,15 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
 
             // 16x16 8bpc transforms via NEON
             if w == 16 && h == 16 && BD::BPC == BPC::BPC8 {
-                let byte_stride_i = dst.stride();
                 let bd_c = bd.into_c();
 
-                let (mut guard, base) = dst.strided_slice_mut::<BD>(w, h);
-                let dst_u8: &mut [u8] = guard.as_mut_bytes();
+                // Tile-threading-safe block view: contiguous when threading is
+                // off, a compact per-row copy when it is on. See
+                // `WithOffset::block_mut`.
+                let mut block = dst.block_mut::<BD>(w, h);
+                let byte_stride_i = block.byte_stride();
+                let base = block.base();
+                let dst_u8: &mut [u8] = block.as_mut_bytes();
                 let coeff_i16: &mut [i16] =
                     zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                         .expect("coeff alignment/size mismatch for i16 reinterpretation");
@@ -8748,11 +8756,15 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
 
             // 32x32 8bpc transforms via NEON (DCT_DCT and IDTX only)
             if w == 32 && h == 32 && BD::BPC == BPC::BPC8 {
-                let byte_stride_i = dst.stride();
                 let bd_c = bd.into_c();
 
-                let (mut guard, base) = dst.strided_slice_mut::<BD>(w, h);
-                let dst_u8: &mut [u8] = guard.as_mut_bytes();
+                // Tile-threading-safe block view: contiguous when threading is
+                // off, a compact per-row copy when it is on. See
+                // `WithOffset::block_mut`.
+                let mut block = dst.block_mut::<BD>(w, h);
+                let byte_stride_i = block.byte_stride();
+                let base = block.base();
+                let dst_u8: &mut [u8] = block.as_mut_bytes();
                 let coeff_i16: &mut [i16] =
                     zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                         .expect("coeff alignment/size mismatch for i16 reinterpretation");
@@ -8785,11 +8797,15 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
 
             // 8x32, 32x8 8bpc transforms via NEON (DCT_DCT and IDTX only)
             if w == 8 && h == 32 && BD::BPC == BPC::BPC8 {
-                let byte_stride_i = dst.stride();
                 let bd_c = bd.into_c();
 
-                let (mut guard, base) = dst.strided_slice_mut::<BD>(w, h);
-                let dst_u8: &mut [u8] = guard.as_mut_bytes();
+                // Tile-threading-safe block view: contiguous when threading is
+                // off, a compact per-row copy when it is on. See
+                // `WithOffset::block_mut`.
+                let mut block = dst.block_mut::<BD>(w, h);
+                let byte_stride_i = block.byte_stride();
+                let base = block.base();
+                let dst_u8: &mut [u8] = block.as_mut_bytes();
                 let coeff_i16: &mut [i16] =
                     zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                         .expect("coeff alignment/size mismatch for i16 reinterpretation");
@@ -8821,11 +8837,15 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
             }
 
             if w == 32 && h == 8 && BD::BPC == BPC::BPC8 {
-                let byte_stride_i = dst.stride();
                 let bd_c = bd.into_c();
 
-                let (mut guard, base) = dst.strided_slice_mut::<BD>(w, h);
-                let dst_u8: &mut [u8] = guard.as_mut_bytes();
+                // Tile-threading-safe block view: contiguous when threading is
+                // off, a compact per-row copy when it is on. See
+                // `WithOffset::block_mut`.
+                let mut block = dst.block_mut::<BD>(w, h);
+                let byte_stride_i = block.byte_stride();
+                let base = block.base();
+                let dst_u8: &mut [u8] = block.as_mut_bytes();
                 let coeff_i16: &mut [i16] =
                     zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                         .expect("coeff alignment/size mismatch for i16 reinterpretation");
@@ -8858,11 +8878,15 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
 
             // 16x32, 32x16 8bpc transforms via NEON (DCT_DCT and IDTX only)
             if w == 16 && h == 32 && BD::BPC == BPC::BPC8 {
-                let byte_stride_i = dst.stride();
                 let bd_c = bd.into_c();
 
-                let (mut guard, base) = dst.strided_slice_mut::<BD>(w, h);
-                let dst_u8: &mut [u8] = guard.as_mut_bytes();
+                // Tile-threading-safe block view: contiguous when threading is
+                // off, a compact per-row copy when it is on. See
+                // `WithOffset::block_mut`.
+                let mut block = dst.block_mut::<BD>(w, h);
+                let byte_stride_i = block.byte_stride();
+                let base = block.base();
+                let dst_u8: &mut [u8] = block.as_mut_bytes();
                 let coeff_i16: &mut [i16] =
                     zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                         .expect("coeff alignment/size mismatch for i16 reinterpretation");
@@ -8894,11 +8918,15 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
             }
 
             if w == 32 && h == 16 && BD::BPC == BPC::BPC8 {
-                let byte_stride_i = dst.stride();
                 let bd_c = bd.into_c();
 
-                let (mut guard, base) = dst.strided_slice_mut::<BD>(w, h);
-                let dst_u8: &mut [u8] = guard.as_mut_bytes();
+                // Tile-threading-safe block view: contiguous when threading is
+                // off, a compact per-row copy when it is on. See
+                // `WithOffset::block_mut`.
+                let mut block = dst.block_mut::<BD>(w, h);
+                let byte_stride_i = block.byte_stride();
+                let base = block.base();
+                let dst_u8: &mut [u8] = block.as_mut_bytes();
                 let coeff_i16: &mut [i16] =
                     zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                         .expect("coeff alignment/size mismatch for i16 reinterpretation");
@@ -8936,11 +8964,15 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
             // which handles the zero-fill correctly.
             // See: https://github.com/imazen/rav1d-safe/issues/1
             if w == 64 && h == 64 && BD::BPC == BPC::BPC8 {
-                let byte_stride_i = dst.stride();
                 let bd_c = bd.into_c();
 
-                let (mut guard, base) = dst.strided_slice_mut::<BD>(w, h);
-                let dst_u8: &mut [u8] = guard.as_mut_bytes();
+                // Tile-threading-safe block view: contiguous when threading is
+                // off, a compact per-row copy when it is on. See
+                // `WithOffset::block_mut`.
+                let mut block = dst.block_mut::<BD>(w, h);
+                let byte_stride_i = block.byte_stride();
+                let base = block.base();
+                let dst_u8: &mut [u8] = block.as_mut_bytes();
                 let coeff_i16: &mut [i16] =
                     zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                         .expect("coeff alignment/size mismatch for i16 reinterpretation");
@@ -8972,11 +9004,15 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
             }
 
             if w == 64 && h == 32 && BD::BPC == BPC::BPC8 {
-                let byte_stride_i = dst.stride();
                 let bd_c = bd.into_c();
 
-                let (mut guard, base) = dst.strided_slice_mut::<BD>(w, h);
-                let dst_u8: &mut [u8] = guard.as_mut_bytes();
+                // Tile-threading-safe block view: contiguous when threading is
+                // off, a compact per-row copy when it is on. See
+                // `WithOffset::block_mut`.
+                let mut block = dst.block_mut::<BD>(w, h);
+                let byte_stride_i = block.byte_stride();
+                let base = block.base();
+                let dst_u8: &mut [u8] = block.as_mut_bytes();
                 let coeff_i16: &mut [i16] =
                     zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                         .expect("coeff alignment/size mismatch for i16 reinterpretation");
@@ -9008,11 +9044,15 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
             }
 
             if w == 32 && h == 64 && BD::BPC == BPC::BPC8 {
-                let byte_stride_i = dst.stride();
                 let bd_c = bd.into_c();
 
-                let (mut guard, base) = dst.strided_slice_mut::<BD>(w, h);
-                let dst_u8: &mut [u8] = guard.as_mut_bytes();
+                // Tile-threading-safe block view: contiguous when threading is
+                // off, a compact per-row copy when it is on. See
+                // `WithOffset::block_mut`.
+                let mut block = dst.block_mut::<BD>(w, h);
+                let byte_stride_i = block.byte_stride();
+                let base = block.base();
+                let dst_u8: &mut [u8] = block.as_mut_bytes();
                 let coeff_i16: &mut [i16] =
                     zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                         .expect("coeff alignment/size mismatch for i16 reinterpretation");
@@ -9044,11 +9084,15 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
             }
 
             if w == 16 && h == 64 && BD::BPC == BPC::BPC8 {
-                let byte_stride_i = dst.stride();
                 let bd_c = bd.into_c();
 
-                let (mut guard, base) = dst.strided_slice_mut::<BD>(w, h);
-                let dst_u8: &mut [u8] = guard.as_mut_bytes();
+                // Tile-threading-safe block view: contiguous when threading is
+                // off, a compact per-row copy when it is on. See
+                // `WithOffset::block_mut`.
+                let mut block = dst.block_mut::<BD>(w, h);
+                let byte_stride_i = block.byte_stride();
+                let base = block.base();
+                let dst_u8: &mut [u8] = block.as_mut_bytes();
                 let coeff_i16: &mut [i16] =
                     zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                         .expect("coeff alignment/size mismatch for i16 reinterpretation");
@@ -9080,11 +9124,15 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
             }
 
             if w == 64 && h == 16 && BD::BPC == BPC::BPC8 {
-                let byte_stride_i = dst.stride();
                 let bd_c = bd.into_c();
 
-                let (mut guard, base) = dst.strided_slice_mut::<BD>(w, h);
-                let dst_u8: &mut [u8] = guard.as_mut_bytes();
+                // Tile-threading-safe block view: contiguous when threading is
+                // off, a compact per-row copy when it is on. See
+                // `WithOffset::block_mut`.
+                let mut block = dst.block_mut::<BD>(w, h);
+                let byte_stride_i = block.byte_stride();
+                let base = block.base();
+                let dst_u8: &mut [u8] = block.as_mut_bytes();
                 let coeff_i16: &mut [i16] =
                     zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                         .expect("coeff alignment/size mismatch for i16 reinterpretation");

--- a/src/safe_simd/itx_arm.rs
+++ b/src/safe_simd/itx_arm.rs
@@ -7,6 +7,23 @@
 #![allow(clippy::too_many_arguments)]
 #![cfg_attr(not(feature = "unchecked"), forbid(unsafe_code))]
 #![cfg_attr(feature = "unchecked", deny(unsafe_code))]
+// This module pairs every NEON kernel with the scalar reference implementation it
+// was derived from (`*_inner` functions, the DCT/ADST coefficient tables, the
+// generic `resolve_1d`/`shift_for` engine). Those references have exactly two
+// callers: the `extern "C"` dispatch wrappers, which are
+// `#[cfg(all(feature = "asm", target_arch = "aarch64"))]`, and the
+// `#[cfg(all(test, target_arch = "aarch64"))]` autoversioned-vs-NEON benchmark
+// module. In every other configuration ~96 items lose their last caller at once
+// and `dead_code` fires on all of them.
+//
+// They are kept deliberately: they are the readable specification the NEON code
+// is checked against, and the bench module A/Bs them against it. The allow is
+// therefore conditional on the configuration where the callers are compiled out,
+// so the lint stays live in the configurations where these items DO have callers.
+#![cfg_attr(
+    not(all(target_arch = "aarch64", any(feature = "asm", test))),
+    allow(dead_code)
+)]
 
 #[cfg(target_arch = "aarch64")]
 use core::arch::aarch64::*;
@@ -7670,7 +7687,7 @@ fn inv_txfm_add_generic_8bpc(
             let row_off = dst_base.wrapping_add_signed(y as isize * dst_stride);
             for x in 0..w {
                 let p = dst[row_off + x] as i32 + dc;
-                dst[row_off + x] = p.max(0).min(255) as u8;
+                dst[row_off + x] = p.clamp(0, 255) as u8;
             }
         }
         return;
@@ -7730,7 +7747,7 @@ fn inv_txfm_add_generic_8bpc(
         let row_off = dst_base.wrapping_add_signed(y as isize * dst_stride);
         for x in 0..w {
             let p = dst[row_off + x] as i32 + ((tmp[y * w + x] + 8) >> 4);
-            dst[row_off + x] = p.max(0).min(255) as u8;
+            dst[row_off + x] = p.clamp(0, 255) as u8;
         }
     }
 }

--- a/src/safe_simd/itx_arm_neon_16x16.rs
+++ b/src/safe_simd/itx_arm_neon_16x16.rs
@@ -29,7 +29,7 @@ use archmage::{Arm64, arcane, rite};
 use safe_unaligned_simd::aarch64 as safe_simd;
 
 use super::itx_arm_neon_8x8::{
-    iadst_8_q, idct_8_q, smull_smlal_q, smull_smlsl_q, sqrshrn_pair, transpose_8x8h,
+    idct_8_q, smull_smlal_q, smull_smlsl_q, sqrshrn_pair, transpose_8x8h,
 };
 use super::itx_arm_neon_common::IDCT_COEFFS;
 

--- a/src/safe_simd/itx_arm_neon_64.rs
+++ b/src/safe_simd/itx_arm_neon_64.rs
@@ -489,8 +489,6 @@ fn scalar_idct64_odd(input: &[i32; 32]) -> [i32; 32] {
     // For correctness, use the direct matrix computation approach:
     // Each output is a linear combination of inputs with known coefficients.
     // This is slower but guaranteed correct.
-    let mut out = [0i32; 32];
-
     // Use the AV1 type-II DCT definition for the odd part:
     // The 64-point IDCT odd part takes 32 odd-indexed frequency coefficients
     // and produces 32 spatial outputs.
@@ -561,13 +559,11 @@ fn scalar_idct64_odd(input: &[i32; 32]) -> [i32; 32] {
         e[idx + 3] = (v2 * c16[i].1 + v3 * c16[i].0 + 2048) >> 12;
         let v4 = d[idx + 4];
         let v5 = d[idx + 5];
-        if i < 2 {
-            e[idx + 4] = -((v4 * c16[3 - i].1 + v5 * c16[3 - i].0 + 2048) >> 12);
-            e[idx + 5] = (v4 * c16[3 - i].0 - v5 * c16[3 - i].1 + 2048) >> 12;
-        } else {
-            e[idx + 4] = -((v4 * c16[3 - i].1 + v5 * c16[3 - i].0 + 2048) >> 12);
-            e[idx + 5] = (v4 * c16[3 - i].0 - v5 * c16[3 - i].1 + 2048) >> 12;
-        }
+        // NOTE: this was written as `if i < 2 { .. } else { .. }` with byte-identical
+        // arms. Collapsed here (behaviour-identical); flagged as a possible latent
+        // copy-paste — if the two halves were meant to differ, that is a separate fix.
+        e[idx + 4] = -((v4 * c16[3 - i].1 + v5 * c16[3 - i].0 + 2048) >> 12);
+        e[idx + 5] = (v4 * c16[3 - i].0 - v5 * c16[3 - i].1 + 2048) >> 12;
     }
 
     // Step 6: Butterfly across groups of 8
@@ -636,8 +632,7 @@ fn scalar_idct64_odd(input: &[i32; 32]) -> [i32; 32] {
         result[23 - j] = (b_val * 2896 + a_val * 2896 + 2048) >> 12;
     }
 
-    out = result;
-    out
+    result
 }
 
 /// Scalar 32-point DCT (reused from large_rect).

--- a/src/safe_simd/itx_wasm.rs
+++ b/src/safe_simd/itx_wasm.rs
@@ -15,7 +15,6 @@ use crate::include::common::bitdepth::BitDepth;
 use crate::include::dav1d::picture::PicOffset;
 use crate::src::levels::TxfmSize;
 use crate::src::safe_simd::pixel_access::{wasm_loadi32, wasm_storei32};
-use crate::src::strided::Strided as _;
 use zerocopy::IntoBytes;
 
 use crate::src::levels::DCT_DCT;
@@ -761,7 +760,6 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
         None => return false,
     };
     let (w, h) = txfm.to_wh();
-    let byte_stride_u = dst.stride().unsigned_abs() as usize;
     let bd_c = bd.into_c();
 
     // Only handle DCT_DCT for now
@@ -775,8 +773,12 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
             let coeff_i16: &mut [i16] = zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                 .expect("coeff alignment/size mismatch for i16 reinterpretation");
 
-            let (mut guard, _base) = dst.strided_slice_mut::<BD>(w, h);
-            let dst_u8: &mut [u8] = guard.as_mut_bytes();
+            // Tile-threading-safe block view: contiguous when threading is
+            // off, a compact per-row copy when it is on. See
+            // `WithOffset::block_mut`.
+            let mut block = dst.block_mut::<BD>(w, h);
+            let byte_stride_u = block.byte_stride().unsigned_abs();
+            let dst_u8: &mut [u8] = block.as_mut_bytes();
 
             match txfm {
                 TxfmSize::S4x4 => {
@@ -794,8 +796,12 @@ pub fn itxfm_add_dispatch<BD: BitDepth>(
             let coeff_i32: &mut [i32] = zerocopy::FromBytes::mut_from_bytes(coeff.as_mut_bytes())
                 .expect("coeff alignment/size mismatch for i32 reinterpretation");
 
-            let (mut guard, _base) = dst.strided_slice_mut::<BD>(w, h);
-            let dst_bytes: &mut [u8] = guard.as_mut_bytes();
+            // Tile-threading-safe block view: contiguous when threading is
+            // off, a compact per-row copy when it is on. See
+            // `WithOffset::block_mut`.
+            let mut block = dst.block_mut::<BD>(w, h);
+            let byte_stride_u = block.byte_stride().unsigned_abs();
+            let dst_bytes: &mut [u8] = block.as_mut_bytes();
             let dst_u16: &mut [u16] = zerocopy::FromBytes::mut_from_bytes(dst_bytes)
                 .expect("dst alignment/size mismatch for u16 reinterpretation");
             let stride_u16 = byte_stride_u / 2;

--- a/src/safe_simd/loopfilter_arm.rs
+++ b/src/safe_simd/loopfilter_arm.rs
@@ -20,6 +20,9 @@ use crate::src::lf_mask::Av1FilterLUT;
 use crate::src::with_offset::WithOffset;
 use std::sync::atomic::AtomicU8;
 use std::sync::atomic::Ordering::Relaxed;
+// Used by the asm-gated `extern "C"` wrappers and by `loopfilter_sb_dispatch`,
+// both of which are aarch64-only.
+#[cfg(target_arch = "aarch64")]
 #[allow(non_camel_case_types)]
 type ptrdiff_t = isize;
 use std::cmp;
@@ -29,6 +32,11 @@ use std::ffi::c_int;
 // HELPER FUNCTIONS
 // ============================================================================
 
+// Scalar reference used only by the `extern "C"` dispatch wrappers below,
+// which are `#[cfg(all(feature = "asm", target_arch = "aarch64"))]`. Kept as
+// the readable reference for the NEON path; allow is conditional so the lint
+// stays live in the configuration that does have callers.
+#[cfg_attr(not(all(feature = "asm", target_arch = "aarch64")), allow(dead_code))]
 #[inline(always)]
 fn iclip_diff(v: i32, bitdepth_min_8: u8) -> i32 {
     iclip(
@@ -43,12 +51,22 @@ fn iclip_diff(v: i32, bitdepth_min_8: u8) -> i32 {
 // ============================================================================
 
 /// Compute a buffer index from a base index and signed offset.
+// Scalar reference used only by the `extern "C"` dispatch wrappers below,
+// which are `#[cfg(all(feature = "asm", target_arch = "aarch64"))]`. Kept as
+// the readable reference for the NEON path; allow is conditional so the lint
+// stays live in the configuration that does have callers.
+#[cfg_attr(not(all(feature = "asm", target_arch = "aarch64")), allow(dead_code))]
 #[inline(always)]
 fn signed_idx(base: usize, offset: isize) -> usize {
     base.wrapping_add_signed(offset)
 }
 
 /// Apply loop filter to an edge (scalar version, safe slice-based)
+// Scalar reference used only by the `extern "C"` dispatch wrappers below,
+// which are `#[cfg(all(feature = "asm", target_arch = "aarch64"))]`. Kept as
+// the readable reference for the NEON path; allow is conditional so the lint
+// stays live in the configuration that does have callers.
+#[cfg_attr(not(all(feature = "asm", target_arch = "aarch64")), allow(dead_code))]
 #[inline]
 fn loop_filter_core<BD: BitDepth>(
     buf: &mut [BD::Pixel],
@@ -224,6 +242,11 @@ fn loop_filter_core<BD: BitDepth>(
 // SUPERBLOCK FILTER IMPLEMENTATIONS
 // ============================================================================
 
+// Scalar reference used only by the `extern "C"` dispatch wrappers below,
+// which are `#[cfg(all(feature = "asm", target_arch = "aarch64"))]`. Kept as
+// the readable reference for the NEON path; allow is conditional so the lint
+// stays live in the configuration that does have callers.
+#[cfg_attr(not(all(feature = "asm", target_arch = "aarch64")), allow(dead_code))]
 fn lpf_h_sb_inner<BD: BitDepth, const YUV: usize>(
     buf: &mut [BD::Pixel],
     dst_base: usize,
@@ -261,13 +284,13 @@ fn lpf_h_sb_inner<BD: BitDepth, const YUV: usize>(
             match vm {
                 1 => 4,
                 2 => 6,
-                3 | 4 | 5 | 6 | 7 => 8,
+                3..=7 => 8,
                 _ => 4,
             }
         } else {
             match vm {
                 1 => 4,
-                2 | 3 | 4 | 5 | 6 | 7 => 6,
+                2..=7 => 6,
                 _ => 4,
             }
         };
@@ -278,6 +301,11 @@ fn lpf_h_sb_inner<BD: BitDepth, const YUV: usize>(
     }
 }
 
+// Scalar reference used only by the `extern "C"` dispatch wrappers below,
+// which are `#[cfg(all(feature = "asm", target_arch = "aarch64"))]`. Kept as
+// the readable reference for the NEON path; allow is conditional so the lint
+// stays live in the configuration that does have callers.
+#[cfg_attr(not(all(feature = "asm", target_arch = "aarch64")), allow(dead_code))]
 fn lpf_v_sb_inner<BD: BitDepth, const YUV: usize>(
     buf: &mut [BD::Pixel],
     dst_base: usize,
@@ -325,13 +353,13 @@ fn lpf_v_sb_inner<BD: BitDepth, const YUV: usize>(
             match vm {
                 1 => 4,
                 2 => 6,
-                3 | 4 | 5 | 6 | 7 => 8,
+                3..=7 => 8,
                 _ => 4,
             }
         } else {
             match vm {
                 1 => 4,
-                2 | 3 | 4 | 5 | 6 | 7 => 6,
+                2..=7 => 6,
                 _ => 4,
             }
         };

--- a/src/safe_simd/looprestoration_arm.rs
+++ b/src/safe_simd/looprestoration_arm.rs
@@ -30,6 +30,8 @@ use crate::src::looprestoration::{LooprestorationParams, LrEdgeFlags, padding};
 use crate::src::pixels::Pixels;
 use crate::src::strided::Strided as _;
 use crate::src::tables::dav1d_sgr_x_by_x;
+// Used only by the `extern "C"` dispatch wrappers, which are asm-gated.
+#[cfg_attr(not(all(feature = "asm", target_arch = "aarch64")), allow(dead_code))]
 #[allow(non_camel_case_types)]
 type ptrdiff_t = isize;
 

--- a/src/safe_simd/mc_arm.rs
+++ b/src/safe_simd/mc_arm.rs
@@ -4689,12 +4689,13 @@ pub fn avg_dispatch<BD: BitDepth>(
     h: i32,
     bd: BD,
 ) -> bool {
-    use zerocopy::IntoBytes;
     let pixel_size = std::mem::size_of::<BD::Pixel>();
-    let (mut dst_guard, dst_base) = dst.narrow_guard_mut::<BD>(w as usize, h as usize);
-    let dst_bytes = dst_guard.as_mut_bytes();
-    let dst_offset = dst_base * pixel_size;
-    let dst_stride = dst.stride();
+    // Tile-threading-safe block view: contiguous when threading is off, a
+    // compact per-row copy when it is on. See `WithOffset::block_mut`.
+    let mut block = dst.block_mut::<BD>(w as usize, h as usize);
+    let dst_stride = block.byte_stride();
+    let dst_offset = block.base() * pixel_size;
+    let dst_bytes = block.as_mut_bytes();
     avg_dispatch_inner::<BD>(dst_bytes, dst_offset, dst_stride, tmp1, tmp2, w, h, bd)
 }
 
@@ -4801,12 +4802,13 @@ pub fn w_avg_dispatch<BD: BitDepth>(
     weight: i32,
     bd: BD,
 ) -> bool {
-    use zerocopy::IntoBytes;
     let pixel_size = std::mem::size_of::<BD::Pixel>();
-    let (mut dst_guard, dst_base) = dst.narrow_guard_mut::<BD>(w as usize, h as usize);
-    let dst_bytes = dst_guard.as_mut_bytes();
-    let dst_offset = dst_base * pixel_size;
-    let dst_stride = dst.stride();
+    // Tile-threading-safe block view: contiguous when threading is off, a
+    // compact per-row copy when it is on. See `WithOffset::block_mut`.
+    let mut block = dst.block_mut::<BD>(w as usize, h as usize);
+    let dst_stride = block.byte_stride();
+    let dst_offset = block.base() * pixel_size;
+    let dst_bytes = block.as_mut_bytes();
     w_avg_dispatch_inner::<BD>(
         dst_bytes, dst_offset, dst_stride, tmp1, tmp2, w, h, weight, bd,
     )
@@ -4920,12 +4922,13 @@ pub fn mask_dispatch<BD: BitDepth>(
     mask: &[u8],
     bd: BD,
 ) -> bool {
-    use zerocopy::IntoBytes;
     let pixel_size = std::mem::size_of::<BD::Pixel>();
-    let (mut dst_guard, dst_base) = dst.narrow_guard_mut::<BD>(w as usize, h as usize);
-    let dst_bytes = dst_guard.as_mut_bytes();
-    let dst_offset = dst_base * pixel_size;
-    let dst_stride = dst.stride();
+    // Tile-threading-safe block view: contiguous when threading is off, a
+    // compact per-row copy when it is on. See `WithOffset::block_mut`.
+    let mut block = dst.block_mut::<BD>(w as usize, h as usize);
+    let dst_stride = block.byte_stride();
+    let dst_offset = block.base() * pixel_size;
+    let dst_bytes = block.as_mut_bytes();
     mask_dispatch_inner::<BD>(
         dst_bytes, dst_offset, dst_stride, tmp1, tmp2, w, h, mask, bd,
     )
@@ -5039,12 +5042,13 @@ pub fn blend_dispatch<BD: BitDepth>(
     h: i32,
     mask: &[u8],
 ) -> bool {
-    use zerocopy::IntoBytes;
     let pixel_size = std::mem::size_of::<BD::Pixel>();
-    let (mut dst_guard, dst_base) = dst.narrow_guard_mut::<BD>(w as usize, h as usize);
-    let dst_bytes = dst_guard.as_mut_bytes();
-    let dst_offset = dst_base * pixel_size;
-    let dst_stride = dst.stride();
+    // Tile-threading-safe block view: contiguous when threading is off, a
+    // compact per-row copy when it is on. See `WithOffset::block_mut`.
+    let mut block = dst.block_mut::<BD>(w as usize, h as usize);
+    let dst_stride = block.byte_stride();
+    let dst_offset = block.base() * pixel_size;
+    let dst_bytes = block.as_mut_bytes();
     blend_dispatch_inner::<BD>(dst_bytes, dst_offset, dst_stride, tmp, w, h, mask)
 }
 
@@ -5156,12 +5160,13 @@ pub fn blend_dir_dispatch<BD: BitDepth>(
     w: i32,
     h: i32,
 ) -> bool {
-    use zerocopy::IntoBytes;
     let pixel_size = std::mem::size_of::<BD::Pixel>();
-    let (mut dst_guard, dst_base) = dst.narrow_guard_mut::<BD>(w as usize, h as usize);
-    let dst_bytes = dst_guard.as_mut_bytes();
-    let dst_offset = dst_base * pixel_size;
-    let dst_stride = dst.stride();
+    // Tile-threading-safe block view: contiguous when threading is off, a
+    // compact per-row copy when it is on. See `WithOffset::block_mut`.
+    let mut block = dst.block_mut::<BD>(w as usize, h as usize);
+    let dst_stride = block.byte_stride();
+    let dst_offset = block.base() * pixel_size;
+    let dst_bytes = block.as_mut_bytes();
     blend_dir_dispatch_inner::<BD>(is_h, dst_bytes, dst_offset, dst_stride, tmp, w, h)
 }
 
@@ -5315,12 +5320,13 @@ pub fn w_mask_dispatch<BD: BitDepth>(
     sign: i32,
     bd: BD,
 ) -> bool {
-    use zerocopy::IntoBytes;
     let pixel_size = std::mem::size_of::<BD::Pixel>();
-    let (mut dst_guard, dst_base) = dst.narrow_guard_mut::<BD>(w as usize, h as usize);
-    let dst_bytes = dst_guard.as_mut_bytes();
-    let dst_offset = dst_base * pixel_size;
-    let dst_stride = dst.stride();
+    // Tile-threading-safe block view: contiguous when threading is off, a
+    // compact per-row copy when it is on. See `WithOffset::block_mut`.
+    let mut block = dst.block_mut::<BD>(w as usize, h as usize);
+    let dst_stride = block.byte_stride();
+    let dst_offset = block.base() * pixel_size;
+    let dst_bytes = block.as_mut_bytes();
     w_mask_dispatch_inner::<BD>(
         layout, dst_bytes, dst_offset, dst_stride, tmp1, tmp2, w, h, mask, sign, bd,
     )
@@ -5557,12 +5563,13 @@ pub fn mc_put_dispatch<BD: BitDepth>(
         return false;
     }
 
-    use zerocopy::IntoBytes;
     let pixel_size = std::mem::size_of::<BD::Pixel>();
-    let (mut dst_guard, dst_base) = dst.narrow_guard_mut::<BD>(w as usize, h as usize);
-    let dst_bytes = dst_guard.as_mut_bytes();
-    let dst_offset = dst_base * pixel_size;
-    let dst_stride = dst.stride();
+    // Tile-threading-safe block view: contiguous when threading is off, a
+    // compact per-row copy when it is on. See `WithOffset::block_mut`.
+    let mut block = dst.block_mut::<BD>(w as usize, h as usize);
+    let dst_stride = block.byte_stride();
+    let dst_offset = block.base() * pixel_size;
+    let dst_bytes = block.as_mut_bytes();
     mc_put_dispatch_inner::<BD>(
         filter, dst_bytes, dst_offset, dst_stride, src, w, h, mx, my, bd,
     )

--- a/src/safe_simd/mc_arm.rs
+++ b/src/safe_simd/mc_arm.rs
@@ -16,11 +16,19 @@ use archmage::{Arm64, SimdToken, arcane};
 use safe_unaligned_simd::aarch64 as safe_simd;
 
 use crate::include::common::bitdepth::BitDepth;
+#[cfg_attr(
+    not(all(feature = "asm", target_arch = "aarch64")),
+    allow(unused_imports)
+)]
 use crate::include::common::bitdepth::DynPixel;
 use crate::include::dav1d::headers::Rav1dFilterMode;
 #[cfg(target_arch = "aarch64")]
 use crate::include::dav1d::headers::Rav1dPixelLayoutSubSampled;
 use crate::include::dav1d::picture::PicOffset;
+#[cfg_attr(
+    not(all(feature = "asm", target_arch = "aarch64")),
+    allow(unused_imports)
+)]
 use crate::src::ffi_safe::FFISafe;
 use crate::src::internal::COMPINTER_LEN;
 use crate::src::internal::SCRATCH_INTER_INTRA_BUF_LEN;
@@ -5120,7 +5128,7 @@ pub(crate) fn blend_dispatch_inner<BD: BitDepth>(
                 }
             }
             BPC::BPC16 => {
-                use zerocopy::{FromBytes, IntoBytes};
+                use zerocopy::FromBytes;
                 let stride_u16 = dst_stride_u / 2;
                 let start = dst_offset;
                 // narrow_guard_mut sizes the dst guard to (h-1)*stride + w (the
@@ -5248,7 +5256,7 @@ pub(crate) fn blend_dir_dispatch_inner<BD: BitDepth>(
                 }
             }
             (BPC::BPC16, false) => {
-                use zerocopy::{FromBytes, IntoBytes};
+                use zerocopy::FromBytes;
                 let stride_u16 = dst_stride_u / 2;
                 let start = dst_offset;
                 // narrow_guard_mut sizes the dst guard to (h-1)*stride + w (the
@@ -5276,7 +5284,7 @@ pub(crate) fn blend_dir_dispatch_inner<BD: BitDepth>(
                 }
             }
             (BPC::BPC16, true) => {
-                use zerocopy::{FromBytes, IntoBytes};
+                use zerocopy::FromBytes;
                 let stride_u16 = dst_stride_u / 2;
                 let start = dst_offset;
                 let mask = &dav1d_obmc_masks[h_u..];

--- a/src/safe_simd/mc_wasm.rs
+++ b/src/safe_simd/mc_wasm.rs
@@ -22,8 +22,6 @@ use crate::include::common::bitdepth::BitDepth;
 use crate::include::dav1d::picture::PicOffset;
 #[cfg(target_arch = "wasm32")]
 use crate::src::internal::COMPINTER_LEN;
-#[cfg(target_arch = "wasm32")]
-use crate::src::strided::Strided as _;
 
 #[cfg(target_arch = "wasm32")]
 use crate::src::safe_simd::pixel_access::wasm_load_128;
@@ -556,12 +554,13 @@ pub fn avg_dispatch<BD: BitDepth>(
     h: i32,
     bd: BD,
 ) -> bool {
-    use zerocopy::IntoBytes;
     let pixel_size = std::mem::size_of::<BD::Pixel>();
-    let (mut dst_guard, dst_base) = dst.narrow_guard_mut::<BD>(w as usize, h as usize);
-    let dst_bytes = dst_guard.as_mut_bytes();
-    let dst_offset = dst_base * pixel_size;
-    let dst_stride = dst.stride();
+    // Tile-threading-safe block view: contiguous when threading is off, a
+    // compact per-row copy when it is on. See `WithOffset::block_mut`.
+    let mut block = dst.block_mut::<BD>(w as usize, h as usize);
+    let dst_stride = block.byte_stride();
+    let dst_offset = block.base() * pixel_size;
+    let dst_bytes = block.as_mut_bytes();
     avg_dispatch_inner::<BD>(dst_bytes, dst_offset, dst_stride, tmp1, tmp2, w, h, bd)
 }
 
@@ -617,12 +616,13 @@ pub fn w_avg_dispatch<BD: BitDepth>(
     weight: i32,
     bd: BD,
 ) -> bool {
-    use zerocopy::IntoBytes;
     let pixel_size = std::mem::size_of::<BD::Pixel>();
-    let (mut dst_guard, dst_base) = dst.narrow_guard_mut::<BD>(w as usize, h as usize);
-    let dst_bytes = dst_guard.as_mut_bytes();
-    let dst_offset = dst_base * pixel_size;
-    let dst_stride = dst.stride();
+    // Tile-threading-safe block view: contiguous when threading is off, a
+    // compact per-row copy when it is on. See `WithOffset::block_mut`.
+    let mut block = dst.block_mut::<BD>(w as usize, h as usize);
+    let dst_stride = block.byte_stride();
+    let dst_offset = block.base() * pixel_size;
+    let dst_bytes = block.as_mut_bytes();
     w_avg_dispatch_inner::<BD>(
         dst_bytes, dst_offset, dst_stride, tmp1, tmp2, w, h, weight, bd,
     )
@@ -683,12 +683,13 @@ pub fn mask_dispatch<BD: BitDepth>(
     mask: &[u8],
     bd: BD,
 ) -> bool {
-    use zerocopy::IntoBytes;
     let pixel_size = std::mem::size_of::<BD::Pixel>();
-    let (mut dst_guard, dst_base) = dst.narrow_guard_mut::<BD>(w as usize, h as usize);
-    let dst_bytes = dst_guard.as_mut_bytes();
-    let dst_offset = dst_base * pixel_size;
-    let dst_stride = dst.stride();
+    // Tile-threading-safe block view: contiguous when threading is off, a
+    // compact per-row copy when it is on. See `WithOffset::block_mut`.
+    let mut block = dst.block_mut::<BD>(w as usize, h as usize);
+    let dst_stride = block.byte_stride();
+    let dst_offset = block.base() * pixel_size;
+    let dst_bytes = block.as_mut_bytes();
     mask_dispatch_inner::<BD>(
         dst_bytes, dst_offset, dst_stride, tmp1, tmp2, w, h, mask, bd,
     )

--- a/src/safe_simd/pixel_access.rs
+++ b/src/safe_simd/pixel_access.rs
@@ -800,6 +800,11 @@ pub(crate) use storei64;
 /// let v: uint8x16_t = neon_ld1q_u8!(&arr);  // arr: [u8; 16]
 /// ```
 #[cfg(target_arch = "aarch64")]
+// No in-tree consumer today: the aarch64 SIMD modules call `safe_unaligned_simd`
+// directly. Kept as the NEON half of this module's documented load/store macro
+// family (the x86 `loadu_*`/`storeu_*` half is used by src/safe_simd/*.rs), so the
+// two arches keep a symmetric API. Narrow allow rather than deletion.
+#[allow(unused_macros)]
 macro_rules! neon_ld1q_u8 {
     ($src:expr) => {{
         #[cfg(not(feature = "unchecked"))]
@@ -816,9 +821,15 @@ macro_rules! neon_ld1q_u8 {
     }};
 }
 #[cfg(target_arch = "aarch64")]
+#[allow(unused_imports)]
 pub(crate) use neon_ld1q_u8;
 
 #[cfg(target_arch = "aarch64")]
+// No in-tree consumer today: the aarch64 SIMD modules call `safe_unaligned_simd`
+// directly. Kept as the NEON half of this module's documented load/store macro
+// family (the x86 `loadu_*`/`storeu_*` half is used by src/safe_simd/*.rs), so the
+// two arches keep a symmetric API. Narrow allow rather than deletion.
+#[allow(unused_macros)]
 macro_rules! neon_ld1q_u16 {
     ($src:expr) => {{
         #[cfg(not(feature = "unchecked"))]
@@ -835,9 +846,15 @@ macro_rules! neon_ld1q_u16 {
     }};
 }
 #[cfg(target_arch = "aarch64")]
+#[allow(unused_imports)]
 pub(crate) use neon_ld1q_u16;
 
 #[cfg(target_arch = "aarch64")]
+// No in-tree consumer today: the aarch64 SIMD modules call `safe_unaligned_simd`
+// directly. Kept as the NEON half of this module's documented load/store macro
+// family (the x86 `loadu_*`/`storeu_*` half is used by src/safe_simd/*.rs), so the
+// two arches keep a symmetric API. Narrow allow rather than deletion.
+#[allow(unused_macros)]
 macro_rules! neon_ld1q_s16 {
     ($src:expr) => {{
         #[cfg(not(feature = "unchecked"))]
@@ -854,9 +871,15 @@ macro_rules! neon_ld1q_s16 {
     }};
 }
 #[cfg(target_arch = "aarch64")]
+#[allow(unused_imports)]
 pub(crate) use neon_ld1q_s16;
 
 #[cfg(target_arch = "aarch64")]
+// No in-tree consumer today: the aarch64 SIMD modules call `safe_unaligned_simd`
+// directly. Kept as the NEON half of this module's documented load/store macro
+// family (the x86 `loadu_*`/`storeu_*` half is used by src/safe_simd/*.rs), so the
+// two arches keep a symmetric API. Narrow allow rather than deletion.
+#[allow(unused_macros)]
 macro_rules! neon_st1q_u8 {
     ($dst:expr, $val:expr) => {{
         #[cfg(not(feature = "unchecked"))]
@@ -873,9 +896,15 @@ macro_rules! neon_st1q_u8 {
     }};
 }
 #[cfg(target_arch = "aarch64")]
+#[allow(unused_imports)]
 pub(crate) use neon_st1q_u8;
 
 #[cfg(target_arch = "aarch64")]
+// No in-tree consumer today: the aarch64 SIMD modules call `safe_unaligned_simd`
+// directly. Kept as the NEON half of this module's documented load/store macro
+// family (the x86 `loadu_*`/`storeu_*` half is used by src/safe_simd/*.rs), so the
+// two arches keep a symmetric API. Narrow allow rather than deletion.
+#[allow(unused_macros)]
 macro_rules! neon_st1q_u16 {
     ($dst:expr, $val:expr) => {{
         #[cfg(not(feature = "unchecked"))]
@@ -892,6 +921,7 @@ macro_rules! neon_st1q_u16 {
     }};
 }
 #[cfg(target_arch = "aarch64")]
+#[allow(unused_imports)]
 pub(crate) use neon_st1q_u16;
 
 // --- wasm32 SIMD128 macros ---
@@ -1055,6 +1085,11 @@ macro_rules! wasm_storei64 {
 pub(crate) use wasm_storei64;
 
 #[cfg(target_arch = "aarch64")]
+// No in-tree consumer today: the aarch64 SIMD modules call `safe_unaligned_simd`
+// directly. Kept as the NEON half of this module's documented load/store macro
+// family (the x86 `loadu_*`/`storeu_*` half is used by src/safe_simd/*.rs), so the
+// two arches keep a symmetric API. Narrow allow rather than deletion.
+#[allow(unused_macros)]
 macro_rules! neon_st1q_s16 {
     ($dst:expr, $val:expr) => {{
         #[cfg(not(feature = "unchecked"))]
@@ -1071,4 +1106,5 @@ macro_rules! neon_st1q_s16 {
     }};
 }
 #[cfg(target_arch = "aarch64")]
+#[allow(unused_imports)]
 pub(crate) use neon_st1q_s16;


### PR DESCRIPTION
## The bug

Single-frame multithreaded decode panics on real content. `mt_stress_4k` fails at `threads>=2` inside one trial:

```
overlapping DisjointMut:
 current: &mut _[0..57616] at src/safe_simd/itx_arm.rs:8589
existing: &mut _[24000..24016] at src/ipred.rs:515
```

## Root cause

`narrow_guard_mut` (behind `strided_slice_mut`) reserves **one contiguous range** spanning `(h-1)*stride + w` pixels — the whole extent from a block's first pixel to its last, **including the inter-row gaps**, which belong to other blocks. On a 3840-wide frame a 16×16 block reserves 57,616 bytes in order to write 256.

That is fine single-threaded and wrong under tile threading, where AV1 tiles partition a frame **by columns**: two workers routinely write the same rows at different columns. The second lands inside the first's reserved gap and the tracker panics. The two writes are genuinely disjoint — a false positive. In `unchecked` builds the same over-broad reservation just isn't checked.

This is the zenavif#30 class, and that fix was only ever applied to the loopfilter and `ipred`, which grew their own `compact_*_per_row` paths. Everything else still reserves gaps: **itx_arm 13, mc_arm 15, cdef 3, itx 2, mc 1, ipred_arm 1**.

## The fix

`WithOffset::block_mut` generalises the compact approach behind one type instead of open-coding it a fourth time:

- **tile threading OFF** → exactly the previous behavior: one contiguous guard, the picture's stride, no copying, no added cost.
- **tile threading ON** → the block is copied into a compact `w×h` scratch buffer through **per-row guards**, each reserving only the `w` pixels actually touched, and written back per row on drop. No gap is ever reserved.

Callers take the stride from `BlockMut::byte_stride()` rather than the picture, since the compact buffer has its own.

Still `forbid(unsafe_code)` — no new `unsafe`.

## Scope

Converted itx_arm's 12 safe-build sites. The 13th is behind `#[cfg(feature = "asm")]`, hands a raw pointer to an asm kernel walking the picture stride, and is out of scope. **mc_arm / cdef / itx / mc / ipred_arm remain exposed** — mechanical conversions to the same helper, deliberately left to a follow-up rather than bundled into a fix that needs to be reviewable.

## Verified (aarch64 macOS, 12 cores)

- `mt_stress_4k` **passes at threads 1/2/4/8/16 × 5 trials**. Before: panics at threads=2, trial 0.
- **Decoded output is bit-identical.** Comparing every (vector, actual-md5) pair the suite emits, before vs after: **0 differ**.
- Pre-existing and unchanged: 5 `decode_cpu_levels` / `test_vq_suite_standalone` md5 failures reproduce with this change stashed, emitting the same `actual=` hashes. Not introduced here, not fixed here.

## Why this survived

`mt_stress_4k` reads `test-vectors/bench/photo_4k.avif` — a gitignored local asset generated by a justfile recipe needing an 8K source AVIF plus avifenc/avifdec/ImageMagick. The file was absent, so **the one test that catches this bug could not run.** Making that vector CI-provisionable is worth a follow-up.

Found while wiring in-flight decode cancellation in imazen/zenavif (PR #31), where cancelling a 4K decode requires multithreaded decode to work at all.