### PR TITLE
fix(ci): gate ablate::Family::bit to __ablate — the Clippy job's only failure

### DIFF
--- a/src/ablate.rs
+++ b/src/ablate.rs
@@ -80,6 +80,11 @@ impl Family {
         Family::ALL.iter().copied().find(|f| f.name() == s)
     }
 
+    /// Only the two `__ablate` call sites (`set_disabled`, `is_off`) use this,
+    /// and both are cfg-gated — so without the feature this is dead code and
+    /// `clippy -D warnings` (the CI job) rejects it. Gate it to match its
+    /// callers rather than silencing the lint.
+    #[cfg(feature = "__ablate")]
     const fn bit(self) -> u32 {
         1u32 << (self as u32)
     }


### PR DESCRIPTION
`Clippy` has been red on `main` since before this campaign's head: `cargo clippy --no-default-features --features "bitdepth_8,bitdepth_16" -- -D warnings` rejects `method 'bit' is never used` (`src/ablate.rs:83`). Found while verifying #462; reported there and in #455 as pre-existing, now fixed.

Both call sites — `set_disabled`'s mask loop and `is_off` — are already inside `#[cfg(feature = "__ablate")]`, so without the feature the method is genuinely dead. Gated to match its callers rather than silenced with `#[allow(dead_code)]`.

Verified on this tree:
- `cargo clippy --no-default-features --features "bitdepth_8,bitdepth_16" -- -D warnings` **rc=0**
- `cargo build --release --features __ablate` still compiles — the ablation harness is unaffected
- `cargo fmt --all --check` clean
- corpus re-run: **766/766**, set-diff BY NAME **0 differing**
- `rav1d-disjoint-mut` suite green under `--features __probe_wide` (8/8 binaries)

**Not fixed, and not a CI problem:** the `Clippy (c-ffi)` leg cannot pass on macOS at all — `src/error.rs:45` asserts `Rav1dError::EAGAIN as u8 == libc::EAGAIN as u8`, which is 11 on Linux and 35 on Darwin. CI runs that job on `ubuntu-latest`, where it holds. Untouched by this work; noting it so the next macOS session doesn't chase it.