### PR TITLE
fix(ci): narrow LfBlock::is_v's dead-code allow — the Clippy job's second and last error

### DIFF
--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -415,6 +415,14 @@ struct LfBlock<'a, 'b, BD: BitDepth> {
     strideb: isize,
     /// `true` for `HV::V` — taps run down the picture and the scratch is
     /// tap-major, which is what lets the vector kernel skip the transpose.
+    ///
+    /// Read by exactly one call site, `filter_run`'s NEON arm, which is
+    /// `#[cfg(target_arch = "aarch64")]`. On every other target the field is
+    /// genuinely never read and `clippy -D warnings` (the CI job, on
+    /// ubuntu-latest x86_64) rejects it. Narrow the allow to the targets where
+    /// the statement is true instead of cfg-ing the field, which would also
+    /// have to cfg the struct literal in `open`.
+    #[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]
     is_v: bool,
 }
 


### PR DESCRIPTION
Follow-on to #463. `-D warnings` aborts after the first error, so gating `ablate::Family::bit` uncovered this rather than introducing it: `field 'is_v' is never read` on x86_64 (CI run 31275432002, job Clippy).

`LfBlock::is_v` has exactly one reader — `filter_run`'s NEON arm, `#[cfg(target_arch = "aarch64")]`. On every other target the lint is correct. `#[cfg_attr(not(target_arch = "aarch64"), allow(dead_code))]` states that where it holds, instead of a blanket `#[allow]` that would also hide a future real dead field on aarch64. Cfg-ing the field would force the struct literal in `open` to be cfg'd too, for nothing.

Reproduced on the CI architecture locally with `--target x86_64-unknown-linux-gnu`. Verified:

| leg | before | after |
|---|---|---|
| clippy x86_64 safe-simd | `field 'is_v' is never read` | **rc=0** |
| clippy x86_64 c-ffi | rc=0 | rc=0 |
| clippy aarch64 safe-simd | rc=0 | rc=0 |

Plus `cargo fmt --all --check` clean and a corpus re-run: **766/766**, set-diff BY NAME **0 differing**.

With this the `Clippy` job should be green for the first time in the campaign; `Format` already went green on the #462 merge.