### PR TITLE
test(disjoint-mut): oracle + Miri gates for the rect primitive — predicate sound over 1.6M pairs, but the guard hands out an aliasing &mut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to the `rav1d-safe` crate are documented in this file. Forma
 
 ## [Unreleased]
 
+### Added
+- **Two soundness gates for the `StridedRows` rectangle borrow**
+  (`crates/rav1d-disjoint-mut/tests/rect_oracle.rs`,
+  `crates/rav1d-disjoint-mut/tests/rect_hull_aliasing.rs`).
+  - `rect_oracle` checks the overlap predicate against a brute-force BYTE-SET
+    oracle over randomized geometries on eight plane shapes (row-map floor 16,
+    non-powers-of-two, a 4K luma row and its 10-bit twin). 1,600,000 pairs:
+    **0 missed overlaps**, and the 2,163 conservative false positives (0.14% of
+    disjoint pairs) all involve a row-crossing interval — the documented
+    `COL_ANY` degradation. Between two shapes the row map CAN describe, the
+    predicate is exact, and the test fails if that stops being true. Mutation
+    proof: narrowing `cols_meet` to test only one edge (a MISSED-overlap bug,
+    i.e. two aliasing `&mut`) leaves **all 9 shipped `rowmap_tests` green** and
+    fails this gate on all eight plane shapes.
+  - `rect_hull_aliasing` records, under Miri, that `index_rect_mut` reserves the
+    rectangle but hands out a `&mut` over the HULL, so two blocks on the same
+    rows in different tile columns are two live overlapping `&mut`. Controls in
+    the same file (per-row guards; one hull guard that is also reserved as the
+    hull) pass, isolating it to the rectangle guard. See the file's module doc.
+
 ### Changed
 - **The borrow tracker shards a picture plane by COLUMN, and a `w x h` block is
   ONE tracked borrow at every thread count**

--- a/crates/rav1d-disjoint-mut/tests/rect_hull_aliasing.rs
+++ b/crates/rav1d-disjoint-mut/tests/rect_hull_aliasing.rs
@@ -1,0 +1,153 @@
+//! Does a rectangle guard hand out MORE than the tracker reserved?
+//!
+//! `index_rect_mut` registers the rectangle (so the inter-row gaps stay
+//! available to other tile columns — the whole point of `StridedRows`) but the
+//! reference it returns is `rect.hull()`, i.e. the gaps included. Two blocks on
+//! the same rows at different columns are therefore accepted by the tracker
+//! while their `&mut [u8]` ranges overlap.
+//!
+//! Run under Miri to decide it:
+//! `cargo +nightly miri test -p rav1d-disjoint-mut --test rect_hull_aliasing`
+
+use rav1d_disjoint_mut::{DisjointMut, StridedRows, set_parallelism};
+
+/// Small enough for Miri, big enough to be sharded (`SHARD_MIN_LEN` = 64 KiB)
+/// and to get a row map (stride >= 16).
+const STRIDE: usize = 256;
+const ROWS: usize = 256;
+const LEN: usize = STRIDE * ROWS;
+
+fn rect(start: usize, w: usize, h: usize) -> StridedRows {
+    StridedRows {
+        start,
+        w,
+        h,
+        stride: STRIDE,
+    }
+}
+
+/// First, without Miri: state the geometry as a plain fact.
+///
+/// This asserts only arithmetic — it passes on any toolchain and documents
+/// exactly what the Miri test below is exercising.
+#[test]
+fn the_hulls_of_two_accepted_rectangles_overlap() {
+    let a = rect(0, 16, 16);
+    let b = rect(64, 16, 16);
+    let a_hull = a.start..a.start + (a.h - 1) * a.stride + a.w;
+    let b_hull = b.start..b.start + (b.h - 1) * b.stride + b.w;
+    assert!(
+        a_hull.start < b_hull.end && b_hull.start < a_hull.end,
+        "the two hulls must overlap for this to be a question: {a_hull:?} vs {b_hull:?}"
+    );
+    // ... while the BYTES each one actually covers are disjoint (columns
+    // 0..=15 versus 64..=79 of the same sixteen rows).
+    for row in 0..16 {
+        let ar = a.start + row * STRIDE..a.start + row * STRIDE + a.w;
+        let br = b.start + row * STRIDE..b.start + row * STRIDE + b.w;
+        assert!(ar.end <= br.start, "row {row}: {ar:?} vs {br:?}");
+    }
+}
+
+/// The tracker accepts both — that part is CORRECT and is what the row map is
+/// for. Kept as its own test so a failure here is read as "the row map broke",
+/// not "the aliasing question changed".
+#[test]
+fn the_tracker_accepts_both() {
+    set_parallelism(8);
+    let mut dm: DisjointMut<Vec<u8>> = DisjointMut::new(vec![0u8; LEN]);
+    dm.set_row_stride(STRIDE);
+    assert!(
+        dm.rect_exact_for(STRIDE),
+        "the row map must be live, or this test proves nothing"
+    );
+    let _a = dm.index_rect_mut(rect(0, 16, 16));
+    let _b = dm.index_rect_mut(rect(64, 16, 16));
+}
+
+/// CONTROL 1: the shape `main` uses under tile threading — `h` per-row guards
+/// per block, two tile columns' worth, all live at once.
+///
+/// If this also tripped Miri, the finding below would be "`DisjointMut` has
+/// always been UB", not "the rectangle guard is". It must pass.
+#[test]
+fn control_per_row_guards_from_two_tile_columns_do_not_alias() {
+    set_parallelism(8);
+    let mut dm: DisjointMut<Vec<u8>> = DisjointMut::new(vec![0u8; LEN]);
+    dm.set_row_stride(STRIDE);
+
+    let mut held = Vec::new();
+    for tile in 0..2 {
+        for row in 0..16 {
+            let off = tile * 64 + row * STRIDE;
+            held.push(dm.index_mut(off..off + 16));
+        }
+    }
+    for (i, g) in held.iter_mut().enumerate() {
+        g[0] = i as u8;
+    }
+    for (i, g) in held.iter().enumerate() {
+        assert_eq!(g[0], i as u8);
+    }
+}
+
+/// CONTROL 2: the shape `main` uses when nothing is parallel — ONE hull guard,
+/// which the tracker also RESERVES as the hull. Exclusive, so it is sound; it
+/// is the correspondence between reserved and handed-out that the rectangle
+/// breaks.
+#[test]
+fn control_one_hull_guard_is_exclusive() {
+    set_parallelism(8);
+    let mut dm: DisjointMut<Vec<u8>> = DisjointMut::new(vec![0u8; LEN]);
+    dm.set_row_stride(STRIDE);
+    let mut hull = dm.index_mut(0..15 * STRIDE + 16);
+    hull[0] = 1;
+    hull[15 * STRIDE] = 2;
+    assert_eq!(hull[0], 1);
+}
+
+/// The question: two live `&mut [u8]` over overlapping memory.
+///
+/// Under Stacked/Tree Borrows, creating `b` retags the shared allocation and
+/// invalidates `a`'s claim to the bytes they share; the write through `a`
+/// afterwards is then UB. Both writes land in bytes each guard genuinely owns —
+/// the aliasing is in the REFERENCES, not in the accesses, which is precisely
+/// why no amount of tracker exactness can fix it.
+#[test]
+fn writing_through_both_guards_while_both_are_live() {
+    set_parallelism(8);
+    let mut dm: DisjointMut<Vec<u8>> = DisjointMut::new(vec![0u8; LEN]);
+    dm.set_row_stride(STRIDE);
+
+    let mut a = dm.index_rect_mut(rect(0, 16, 16));
+    let mut b = dm.index_rect_mut(rect(64, 16, 16));
+
+    // Byte 0 of `a`'s slice is column 0; byte 0 of `b`'s slice is column 64.
+    // Disjoint bytes, overlapping references.
+    b[0] = 2;
+    a[0] = 1;
+    assert_eq!(b[0], 2);
+    assert_eq!(a[0], 1);
+}
+
+/// The same shape the shipped mechanism test holds: four tile columns plus the
+/// 1-pixel intra left column each of them reads. Seven live guards, every pair
+/// of hulls overlapping.
+#[test]
+fn four_tile_columns_the_way_the_decoder_holds_them() {
+    set_parallelism(8);
+    let mut dm: DisjointMut<Vec<u8>> = DisjointMut::new(vec![0u8; LEN]);
+    dm.set_row_stride(STRIDE);
+
+    let mut held = Vec::new();
+    for tile in 0..4 {
+        held.push(dm.index_rect_mut(rect(tile * 64, 16, 16)));
+    }
+    // Touch every guard while all four are live.
+    for (i, g) in held.iter_mut().enumerate() {
+        g[0] = i as u8;
+    }
+    for (i, g) in held.iter().enumerate() {
+        assert_eq!(g[0], i as u8);
+    }
+}

--- a/crates/rav1d-disjoint-mut/tests/rect_oracle.rs
+++ b/crates/rav1d-disjoint-mut/tests/rect_oracle.rs
@@ -1,0 +1,390 @@
+//! Is the rectangle overlap predicate EXACT, against a brute-force oracle?
+//!
+//! The tracker's exactness argument is what makes the crate's 65 `unsafe` uses
+//! sound, and the rectangle primitive rests it on two cheap comparisons (hull
+//! overlap AND column overlap) instead of any row arithmetic. The argument is
+//! written out on `ShardRecs::c0`; this checks it by experiment.
+//!
+//! The oracle is a literal byte set: paint every byte shape A covers into a
+//! plane, then ask whether any byte shape B covers is already painted. No
+//! geometry reasoning is transcribed from the implementation — if the two ever
+//! disagree, one of them is wrong and the test says which direction:
+//!
+//! * oracle says overlap, tracker says no  → **MISSED OVERLAP**, i.e. two
+//!   aliasing `&mut` handed out. Unsound.
+//! * oracle says disjoint, tracker says yes → **FALSE POSITIVE**, i.e. the
+//!   spurious `overlapping DisjointMut` panic the per-row split existed to
+//!   avoid (PR #467 measured 8-9 of them in 24 concurrent runs).
+//!
+//! Iterations default low so this stays a fast gate; set `RECT_ORACLE_ITERS`
+//! for a soak.
+
+use rav1d_disjoint_mut::{DisjointMut, StridedRows, set_parallelism};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+/// `SHARD_MIN_LEN`: below this the tracker does not shard, and the row map is
+/// not consulted at all.
+const MIN_LEN: usize = 64 * 1024;
+
+/// SplitMix64. Deterministic and seeded, so a failure is reproducible from the
+/// seed printed in the panic message.
+struct Rng(u64);
+
+impl Rng {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform in `0..n`.
+    fn below(&mut self, n: usize) -> usize {
+        (self.next_u64() % (n as u64)) as usize
+    }
+
+    /// Uniform in `lo..=hi`.
+    fn range(&mut self, lo: usize, hi: usize) -> usize {
+        lo + self.below(hi - lo + 1)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Shape {
+    Rect { start: usize, w: usize, h: usize },
+    Interval { start: usize, end: usize },
+}
+
+impl Shape {
+    /// THE ORACLE. Every byte this shape covers, enumerated one at a time.
+    ///
+    /// Deliberately the dumbest possible definition — a rectangle is its rows,
+    /// an interval is its range. Nothing here knows about hulls, columns,
+    /// bands, groups or shards.
+    fn for_each_byte(&self, stride: usize, mut f: impl FnMut(usize)) {
+        match *self {
+            Shape::Rect { start, w, h } => {
+                for row in 0..h {
+                    for col in 0..w {
+                        f(start + row * stride + col);
+                    }
+                }
+            }
+            Shape::Interval { start, end } => {
+                for b in start..end {
+                    f(b);
+                }
+            }
+        }
+    }
+
+    /// Does this shape span more than one row?
+    ///
+    /// A rectangle never does *in the column sense* — its columns are the same
+    /// in every row. An INTERVAL that runs off the end of its row does, and
+    /// that is the one shape the row map cannot describe: it registers
+    /// `0..=COL_ANY` and falls back to the plain hull test, which is
+    /// conservative. This classifier is what separates "known degradation"
+    /// from "new bug".
+    fn crosses_row(&self, stride: usize) -> bool {
+        match *self {
+            Shape::Rect { .. } => false,
+            Shape::Interval { start, end } => start / stride != (end - 1) / stride,
+        }
+    }
+
+    /// Highest byte touched, +1 — for the in-bounds check.
+    fn limit(&self, stride: usize) -> usize {
+        match *self {
+            Shape::Rect { start, w, h } => start + (h - 1) * stride + w,
+            Shape::Interval { end, .. } => end,
+        }
+    }
+}
+
+/// Random shape. Biased on purpose towards the geometries the decoder makes:
+/// small aligned blocks, one-pixel edge columns, full rows, and the
+/// deliberately-unaligned reads (`ipred`'s x-1, CDEF's x-2, MC's x-3).
+fn gen_shape(rng: &mut Rng, stride: usize, rows: usize) -> Shape {
+    let kind = rng.below(10);
+    if kind < 7 {
+        // A rectangle.
+        let w = match rng.below(8) {
+            0 => 1,
+            1 => rng.range(1, 4),
+            2 => stride.min(rng.range(1, 64)),
+            3 => stride,                           // a full row
+            _ => stride.min(1 << rng.range(2, 6)), // 4..32, the aligned sizes
+        };
+        let h = match rng.below(4) {
+            0 => 1,
+            1 => rng.range(1, 4),
+            _ => rng.range(1, 32.min(rows)),
+        };
+        let h = h.min(rows);
+        let col = rng.below(stride - w + 1);
+        let row = rng.below(rows - h + 1);
+        Shape::Rect {
+            start: row * stride + col,
+            w,
+            h,
+        }
+    } else {
+        // A plain interval, often crossing a row boundary.
+        let len = match rng.below(4) {
+            0 => rng.range(1, 8),
+            1 => rng.range(1, 64),
+            _ => rng.range(1, 2 * stride),
+        };
+        let max_start = stride * rows - len;
+        Shape::Interval {
+            start: rng.below(max_start + 1),
+            end: 0,
+        }
+        .with_len(len)
+    }
+}
+
+impl Shape {
+    fn with_len(self, len: usize) -> Self {
+        match self {
+            Shape::Interval { start, .. } => Shape::Interval {
+                start,
+                end: start + len,
+            },
+            other => other,
+        }
+    }
+}
+
+/// Take the borrow the shape describes, mutably. Returns `true` if the tracker
+/// REFUSED it (panicked with an overlap).
+fn conflicts(dm: &DisjointMut<Vec<u8>>, shape: Shape, stride: usize) -> bool {
+    catch_unwind(AssertUnwindSafe(|| match shape {
+        Shape::Rect { start, w, h } => {
+            let g = dm.index_rect_mut(StridedRows {
+                start,
+                w,
+                h,
+                stride,
+            });
+            drop(g);
+        }
+        Shape::Interval { start, end } => {
+            let g = dm.index_mut(start..end);
+            drop(g);
+        }
+    }))
+    .is_err()
+}
+
+/// Hold the borrow open, so the second one sees it.
+fn hold<'a>(
+    dm: &'a DisjointMut<Vec<u8>>,
+    shape: Shape,
+    stride: usize,
+) -> rav1d_disjoint_mut::DisjointMutGuard<'a, Vec<u8>, [u8]> {
+    match shape {
+        Shape::Rect { start, w, h } => dm.index_rect_mut(StridedRows {
+            start,
+            w,
+            h,
+            stride,
+        }),
+        Shape::Interval { start, end } => dm.index_mut(start..end),
+    }
+}
+
+fn iters() -> usize {
+    std::env::var("RECT_ORACLE_ITERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1500)
+}
+
+/// The property, over one plane shape.
+fn run_stride(
+    stride: usize,
+    rows: usize,
+    seed: u64,
+    n: usize,
+) -> Result<(usize, usize, usize), String> {
+    let len = stride * rows;
+    assert!(
+        len >= MIN_LEN,
+        "stride {stride} x {rows} rows is not sharded"
+    );
+
+    set_parallelism(8);
+    let mut dm: DisjointMut<Vec<u8>> = DisjointMut::new(vec![0u8; len]);
+    dm.set_row_stride(stride);
+
+    let mut painted = vec![false; len];
+    let mut rng = Rng(seed);
+    let (mut n_overlap, mut n_disjoint) = (0usize, 0usize);
+    let mut n_false_pos = 0usize;
+
+    for i in 0..n {
+        let a = gen_shape(&mut rng, stride, rows);
+        let b = gen_shape(&mut rng, stride, rows);
+        if a.limit(stride) > len || b.limit(stride) > len {
+            continue;
+        }
+
+        // ORACLE: paint A, then ask whether B lands on any painted byte.
+        a.for_each_byte(stride, |o| painted[o] = true);
+        let mut truth = false;
+        b.for_each_byte(stride, |o| truth |= painted[o]);
+
+        // TRACKER: hold A, try B.
+        let held = hold(&dm, a, stride);
+        let observed = conflicts(&dm, b, stride);
+        drop(held);
+
+        // Clean up the oracle plane for the next round.
+        a.for_each_byte(stride, |o| painted[o] = false);
+
+        if truth && !observed {
+            // SOUNDNESS. No tolerance, no classification, no excuse: the
+            // tracker handed out two aliasing `&mut`.
+            return Err(format!(
+                "MISSED OVERLAP (UNSOUND)\n  \
+                 stride={stride} rows={rows} seed={seed} iter={i}\n  \
+                 A = {a:?}\n  B = {b:?}"
+            ));
+        }
+        if !truth && observed {
+            // A spurious panic. Tolerated ONLY where the design documents it:
+            // an interval that runs off the end of its row cannot be described
+            // as a rectangle, registers `0..=COL_ANY`, and degrades to the
+            // plain hull test. Between two shapes the map CAN describe, the
+            // predicate is supposed to be exact — so that case is a new bug.
+            n_false_pos += 1;
+            if !(a.crosses_row(stride) || b.crosses_row(stride)) {
+                return Err(format!(
+                    "FALSE POSITIVE between two describable shapes\n  \
+                     stride={stride} rows={rows} seed={seed} iter={i}\n  \
+                     A = {a:?}\n  B = {b:?}\n  \
+                     neither crosses a row, so both have real column ranges \
+                     and the pair should have been exact"
+                ));
+            }
+        }
+
+        if truth {
+            n_overlap += 1;
+        } else {
+            n_disjoint += 1;
+        }
+
+        // Hygiene: nothing may be left registered. A partially-published
+        // borrow surviving a caught panic would show up here and nowhere else.
+        drop(dm.index_mut(0..len));
+    }
+    Ok((n_overlap, n_disjoint, n_false_pos))
+}
+
+/// Silence the panic hook for the duration: the tracker panics thousands of
+/// times on purpose here, and each one prints a multi-line message.
+fn quietly<R>(f: impl FnOnce() -> R) -> R {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let r = catch_unwind(AssertUnwindSafe(f));
+    std::panic::set_hook(prev);
+    match r {
+        Ok(v) => v,
+        Err(e) => std::panic::resume_unwind(e),
+    }
+}
+
+#[test]
+fn rect_versus_rect_and_rect_versus_interval_match_a_byte_set_oracle() {
+    // Plane shapes: the row-map floor (16), non-powers-of-two, a real 4K luma
+    // row, and its 10-bit twin.
+    let planes: &[(usize, usize)] = &[
+        (16, 4096),
+        (64, 1024),
+        (100, 800),
+        (128, 512),
+        (256, 256),
+        (257, 256),
+        (3840, 32),
+        (4096, 32),
+    ];
+    let n = iters();
+    let mut tot_overlap = 0usize;
+    let mut tot_disjoint = 0usize;
+    let mut tot_false_pos = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+    quietly(|| {
+        for (i, &(stride, rows)) in planes.iter().enumerate() {
+            match run_stride(stride, rows, 0xC0FFEE ^ (i as u64), n) {
+                Ok((o, d, fp)) => {
+                    tot_overlap += o;
+                    tot_disjoint += d;
+                    tot_false_pos += fp;
+                }
+                Err(e) => failures.push(e),
+            }
+        }
+    });
+    if !failures.is_empty() {
+        panic!(
+            "{} plane shape(s) disagreed with the oracle:\n\n{}",
+            failures.len(),
+            failures.join("\n\n")
+        );
+    }
+
+    // LIVENESS: a run that never produced both answers proves nothing. The
+    // false-positive direction needs disjoint pairs and the missed-overlap
+    // direction needs overlapping ones.
+    assert!(
+        tot_overlap > 100 && tot_disjoint > 100,
+        "degenerate generator: {tot_overlap} overlapping / {tot_disjoint} disjoint pairs"
+    );
+    eprintln!(
+        "rect oracle: {tot_overlap} overlapping / {tot_disjoint} disjoint pairs; \
+         0 missed overlaps; {tot_false_pos} conservative false positives \
+         ({:.2}% of disjoint pairs), all involving a row-crossing interval",
+        100.0 * tot_false_pos as f64 / tot_disjoint.max(1) as f64
+    );
+}
+
+/// Two IMMUTABLE borrows must never conflict, whatever their geometry.
+#[test]
+fn two_immutable_rectangles_never_conflict() {
+    const STRIDE: usize = 256;
+    const ROWS: usize = 256;
+    set_parallelism(8);
+    let mut dm: DisjointMut<Vec<u8>> = DisjointMut::new(vec![0u8; STRIDE * ROWS]);
+    dm.set_row_stride(STRIDE);
+    let mut rng = Rng(0xBEEF);
+    for _ in 0..500 {
+        let a = gen_shape(&mut rng, STRIDE, ROWS);
+        let b = gen_shape(&mut rng, STRIDE, ROWS);
+        if a.limit(STRIDE) > STRIDE * ROWS || b.limit(STRIDE) > STRIDE * ROWS {
+            continue;
+        }
+        // Immutable pair: take both at once, no panic is permitted.
+        let _ia = match a {
+            Shape::Rect { start, w, h } => Some(dm.index_rect(StridedRows {
+                start,
+                w,
+                h,
+                stride: STRIDE,
+            })),
+            Shape::Interval { .. } => None,
+        };
+        let _ib = match b {
+            Shape::Rect { start, w, h } => Some(dm.index_rect(StridedRows {
+                start,
+                w,
+                h,
+                stride: STRIDE,
+            })),
+            Shape::Interval { .. } => None,
+        };
+    }
+}


### PR DESCRIPTION
Stacked on #469 (base `perf/strided-rect` @ 4db4144). Adds the two gates that PR's `Not measured` list names — a randomized oracle and Miri — and one of them fails.

## BLOCKING: the rectangle guard hands out a `&mut` wider than it reserved

`index_rect_mut` registers the **rectangle** and returns a `&mut [T]` over `rect.hull()`. The CHANGELOG entry states the split deliberately — *"records the hull as the reference and the exact rectangle as the record"* — and that is the defect: the reference is what Rust's aliasing rules apply to, so two blocks on the same rows in different tile columns are two **simultaneously live overlapping `&mut`**. That is the case the row map exists to allow, so it is not a corner.

```
A = rect(start 0,  w 16, h 16, stride 256)  -> hull [0x000 .. 0xf10)
B = rect(start 64, w 16, h 16, stride 256)  -> hull [0x040 .. 0xf50)
bytes: columns 0..=15 vs 64..=79 of the same 16 rows — disjoint
refs:  the two hulls overlap by 3,792 bytes
```

Miri, `crates/rav1d-disjoint-mut/tests/rect_hull_aliasing.rs`:

```
error: Undefined Behavior: trying to retag from <131284> for Unique permission
       at alloc42031[0x40], but that tag does not exist in the borrow stack
help: <131284> was created by a Unique retag at offsets [0x0..0xf10]
help: <131284> was later invalidated at offsets [0x40..0xf50] by a Unique retag
```

| under Miri | |
|---|---|
| CONTROL — `h` per-row guards from two tile columns, 32 live (what `main` does at t>1) | **pass** |
| CONTROL — one hull guard, which the tracker also RESERVES as the hull (what `main` does at t=1) | **pass** |
| two rect guards created, earlier one never used again | pass |
| two rect guards, write through both while both live | **UB** |
| four tile columns held the way the decoder holds them | **UB** |

The controls are the point: this is the rectangle guard, not `DisjointMut` generally. `StridedRows` does not exist on `main` (`git show ee07b00:…/lib.rs | grep -c StridedRows` → 0), so the hazard arrives with the primitive.

**Reachable on the real path**, not just in the test: `for_rows_mut` does `f(row, &mut guard[idx..][..w])` (`include/dav1d/picture.rs:1185`) — it writes through the hull guard while holding it, and two tile workers do that concurrently on overlapping hulls by design.

### The fix does not cost the win
The win is **one registration** per block; the reference shape is independent of it. A guard that keeps the base pointer and hands out `&mut` **per row** keeps the single registration and makes the references disjoint (rows of one rect are disjoint from each other and, by the tracker, from every other borrow). No extra atomic, no extra lock.

Scope: 7 call sites. Five index by row inside the function and are mechanical (`for_rows`, `for_rows_mut`, `compact_read_per_row`, `compact_write_back_per_row`, `LfBlock::fill`). Two — `narrow_guard` / `narrow_guard_mut` — return the guard to their callers, so the row view has to travel. Immutable rects need it too: a `&` over the hull aliases another column's `&mut` in the gaps.

I did not attempt it here rather than land a half-refactor with no re-measurement.

## The predicate itself is sound — measured, not argued

`crates/rav1d-disjoint-mut/tests/rect_oracle.rs`. The oracle is a literal byte set: paint every byte A covers, ask whether any byte B covers is painted. Nothing about hulls, columns, bands or shards is transcribed from the implementation. Eight plane shapes (row-map floor 16, non-powers-of-two 100/257, a 4K luma row and its 10-bit twin), randomized rect-vs-rect and rect-vs-interval, `RECT_ORACLE_ITERS=200000`:

**1,600,000 pairs — 63,020 overlapping / 1,536,980 disjoint — 0 missed overlaps.**

2,163 conservative false positives (0.14% of disjoint pairs), **all** involving a row-crossing interval. That is the documented `COL_ANY` fallback to the plain hull test, but it does qualify this PR's summary line, which says the pair is *"EXACT, not conservative"* without the caveat that this holds only when **both** records have real column ranges. The gate splits on exactly that line: missed overlaps are a hard zero, false positives are permitted only where at least one shape crosses a row, so a false positive between two describable shapes fails.

Worth noting because a spurious `overlapping DisjointMut` panic is a decode failure, and it is the hazard #467 hit (8–9 in 24 concurrent runs).

## Teeth

Narrow `cols_meet` from `a0 <= b1 && b0 <= a1` to `a0 <= b0 && b0 <= a1`, so it misses every overlap where B starts left of A — a missed overlap **is** two aliasing `&mut`:

- all **9** shipped `rowmap_tests`: **green**
- `rect_oracle`: **fails on all eight plane shapes**, labelled `MISSED OVERLAP (UNSOUND)`

Restored byte-exact (sha256 `06c5d452…` before and after, `git diff` clean, suite green). The shipped mechanism suite had a hole in the soundness direction; this closes it.

## Also verified
- Corpus **766/766**, set-diff BY NAME with the actual md5 as the value vs `benchmarks/aarch64_md5_fixes_2026-08-07_final.tsv.zst`: 0 only-in-baseline / 0 only-in-head / 0 differing. #469's correctness claim holds.
- `cargo test -p rav1d-disjoint-mut` green (35 + 25 + 6 + 5 + 2 + 1 + 1); `cargo fmt --check` clean.

## Not done
I did **not** re-run the dav1d gap sweep, `mt_stress`, or `multi_decoder_pressure.sh` — #469's own numbers stand unchallenged and re-running them adds nothing while the reference-aliasing question is open. No x86_64. No fix. `rect_hull_aliasing` passes on stable by construction (UB is not a runtime failure) — it is a Miri gate and CI must run it under Miri to have any teeth.
