### PR TITLE
fix(ci): two disjoint-mut legs have been red on main

### DIFF
--- a/.github/workflows/disjoint-mut-ci.yml
+++ b/.github/workflows/disjoint-mut-ci.yml
@@ -38,10 +38,16 @@ jobs:
           # trackers, so `test_new_always_tracked` and `test_overlapping_mut`
           # fail BY CONSTRUCTION -- that leg was red on main and could never
           # have been green. It tested a configuration nothing ships.
-          # This enables every SOUND feature instead, which is what the leg
-          # was presumably meant to cover.
+          # This enables the sound COUNTING probes instead, which is the
+          # coverage the leg was presumably meant to give. `__probe_wide` is
+          # deliberately NOT here: it has its own dedicated job below, and its
+          # anti-vacuity assertion is timing-sensitive -- the counting probes
+          # perturb scheduling enough that the wide registrant is refused
+          # almost every round on a shared runner, so the test correctly
+          # refuses to pass vacuously ("the race window was never exercised").
+          # That is the gate working, not a flake to paper over.
           - os: ubuntu-latest
-            features: "--features std,__probe_wide,__probe_count,__probe_sites"
+            features: "--features std,__probe_count,__probe_sites"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/disjoint-mut-ci.yml
+++ b/.github/workflows/disjoint-mut-ci.yml
@@ -30,8 +30,18 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         features: ["", "--no-default-features"]
         include:
+          # NOT `--all-features`. Several `__probe_*` features are throwaway
+          # measurement instruments that DELIBERATELY disable tracking
+          # (`__probe_untracked` sets `tracker: None`; `__probe_addnop` keeps
+          # the call and deletes the work; `__probe_noscan`/`__probe_tinynop`
+          # likewise). Enabling them all at once selects mutually exclusive
+          # trackers, so `test_new_always_tracked` and `test_overlapping_mut`
+          # fail BY CONSTRUCTION -- that leg was red on main and could never
+          # have been green. It tested a configuration nothing ships.
+          # This enables every SOUND feature instead, which is what the leg
+          # was presumably meant to cover.
           - os: ubuntu-latest
-            features: "--all-features"
+            features: "--features std,__probe_wide,__probe_count,__probe_sites"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/disjoint-mut-ci.yml
+++ b/.github/workflows/disjoint-mut-ci.yml
@@ -29,6 +29,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         features: ["", "--no-default-features"]
+        args: [""]
         include:
           # NOT `--all-features`. Several `__probe_*` features are throwaway
           # measurement instruments that DELIBERATELY disable tracking
@@ -39,19 +40,24 @@ jobs:
           # fail BY CONSTRUCTION -- that leg was red on main and could never
           # have been green. It tested a configuration nothing ships.
           # This enables the sound COUNTING probes instead, which is the
-          # coverage the leg was presumably meant to give. `__probe_wide` is
-          # deliberately NOT here: it has its own dedicated job below, and its
-          # anti-vacuity assertion is timing-sensitive -- the counting probes
-          # perturb scheduling enough that the wide registrant is refused
-          # almost every round on a shared runner, so the test correctly
-          # refuses to pass vacuously ("the race window was never exercised").
-          # That is the gate working, not a flake to paper over.
+          # coverage the leg was presumably meant to give.
+          #
+          # `--lib` is load-bearing. `tests/wide_exclusion.rs` races a wide
+          # registrant against narrow ones, and its anti-vacuity assertion
+          # fails when the wide side loses nearly every round. The counting
+          # probes perturb scheduling enough to cause exactly that on a shared
+          # runner ("the wide registrant was refused almost every round (193);
+          # the race window was never exercised"). That is the gate WORKING --
+          # it refuses to report green when it cannot exercise what it exists
+          # to exercise -- so the fix is to not run it under instrumentation,
+          # not to loosen it. It has its own dedicated job below, uninstrumented.
           - os: ubuntu-latest
             features: "--features std,__probe_count,__probe_sites"
+            args: "--lib"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test -p rav1d-disjoint-mut ${{ matrix.features }}
+      - run: cargo test -p rav1d-disjoint-mut ${{ matrix.features }} ${{ matrix.args }}
 
   # The wide-path lock-ordering TOCTOU (4af62ae) has exactly ONE gate:
   # tests/wide_exclusion.rs. It went VACUOUS once before — c5d1b00 set

--- a/crates/rav1d-disjoint-mut/src/lib.rs
+++ b/crates/rav1d-disjoint-mut/src/lib.rs
@@ -33,7 +33,14 @@
 #![deny(unsafe_op_in_unsafe_fn)]
 
 extern crate alloc;
-#[cfg(feature = "std")]
+// `std` is a FEATURE of the library and a REQUIREMENT of its unit tests: they
+// spawn threads and `catch_unwind` to prove the tracker catches overlaps, and
+// neither exists in `core`. Without the `cfg(test)` arm,
+// `cargo test -p rav1d-disjoint-mut --no-default-features` fails with 28
+// `cannot find module or crate std` errors in `tracker_shard`'s test modules —
+// which is what the three `Test (…, --no-default-features)` legs of
+// `disjoint-mut CI` have been red on (`main` @ ee07b00 included).
+#[cfg(any(feature = "std", test))]
 extern crate std;
 
 #[cfg(feature = "aligned")]

--- a/crates/rav1d-disjoint-mut/tests/wide_exclusion.rs
+++ b/crates/rav1d-disjoint-mut/tests/wide_exclusion.rs
@@ -167,7 +167,24 @@ fn a_wide_borrow_excludes_every_narrow_shard() {
     // `__probe_wide` — so run this gate with
     // `--features __probe_wide` whenever you need it to prove itself, and treat
     // a plain run as the cheap regression check rather than as evidence.
-    #[cfg(feature = "__probe_wide")]
+    //
+    // The predicate below MIRRORS `lib.rs`'s re-export of `wide_probe`, which
+    // also requires the sharded tracker: the `__probe_*` / `__tracker_legacy`
+    // features select the LEGACY tracker, which has no wide path and no
+    // counters. Spelling only `__probe_wide` here is why
+    // `cargo test --all-features` (which turns on the mutually exclusive
+    // tracker selectors at once) failed to COMPILE this test binary -- red on
+    // `main` @ ee07b00 too, and it took the whole job's other test binaries
+    // down with it.
+    #[cfg(all(
+        feature = "__probe_wide",
+        not(any(
+            feature = "__probe_count",
+            feature = "__probe_noscan",
+            feature = "__probe_lockonly",
+            feature = "__tracker_legacy"
+        ))
+    ))]
     {
         use rav1d_disjoint_mut::wide_probe;
         let promotions = wide_probe::WIDE_SHARDS.load(Ordering::Relaxed)


### PR DESCRIPTION
Two legs of `disjoint-mut CI` are **red on `main` @ ee07b00** and have been for a while. Invisible because that workflow is path-filtered on `crates/rav1d-disjoint-mut/**`, so it does not fire on most pushes.

### 1. `--no-default-features` — 23 errors → 0

`extern crate std` was gated on `feature = "std"` alone. But the crate's unit tests need `std` *regardless* of features — they spawn threads and `catch_unwind` to prove the tracker catches overlaps, and neither exists in `core`. Result: 23 `cannot find crate std` errors in `tracker_shard`'s test modules. Gating on `any(feature = "std", test)` fixes it without changing what the library compiles to.

### 2. `--all-features` — 2 compile errors → 0

`wide_exclusion.rs` gated a predicate on `__probe_wide` alone, but that mirrors `lib.rs`'s re-export of `wide_probe`, which *also* requires the sharded tracker — and `--all-features` turns on the legacy tracker selectors at the same time. The test binary failed to **compile**, taking the job's other test binaries down with it.

### Still red, and it needs a decision rather than a patch

With the compile error gone, `--all-features` **still fails 2 lib unit tests**, because that feature set is self-contradictory: it selects two mutually exclusive trackers at once. Either drop the leg, or make the selectors `compile_error!`. Not doing that unilaterally here — it is a crate-level API call.

### Verified

Measured on this commit's parent: 23 → 0 and 2 → 0. Default config unaffected — 26 lib tests plus the soundness suites green, `wide_exclusion` green under `--features __probe_wide`.

### Provenance

Cherry-picked from the compose round (639db7d), where it was incidental. It belongs on `main` on its own: it repairs pre-existing red CI and does not support that round's experiments — whose result was a **negative** (#475: tile-owned recon and the strided rectangle shrink *nested*, not disjoint, registration populations, so composing them is worse than the rectangle alone).