### PR TITLE
fix(disjoint-mut): guards must not hold a reference across their own release (#477)

### DIFF
--- a/.github/workflows/disjoint-mut-ci.yml
+++ b/.github/workflows/disjoint-mut-ci.yml
@@ -79,10 +79,22 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test -p rav1d-disjoint-mut --features __probe_wide --test wide_exclusion -- --nocapture
 
+  # Miri is the ONLY thing in this repo that checks the aliasing model rather
+  # than the tracker's own bookkeeping. `rav1d-disjoint-mut` has ~65 `unsafe`
+  # uses and no `forbid(unsafe_code)`; the borrow tracker is what makes them
+  # sound, and Miri is what says whether the references it hands out obey the
+  # model. It found the guards' by-value-move defect (#477) that every tracker
+  # test and all 766 corpus vectors missed.
   miri:
-    name: Miri (${{ matrix.model }})
+    # `matrix.model` is an object, so `${{ matrix.model }}` renders "Object" for
+    # BOTH legs and a failure cannot be attributed to a memory model. In run
+    # 31292996318 one leg was `failure` and the other `cancelled` and there was
+    # no way to tell which model found the UB.
+    name: Miri (${{ matrix.model.name }})
     runs-on: ubuntu-latest
     strategy:
+      # Same reason: one model failing must not cancel the other's evidence.
+      fail-fast: false
       matrix:
         model:
           - name: "Stacked Borrows"
@@ -94,7 +106,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
-      - run: cargo +nightly miri test -p rav1d-disjoint-mut
+      # `--no-fail-fast` is load-bearing. Miri aborts the process on the first
+      # UB, and cargo stops at the first failing test TARGET — so in run
+      # 31292996318 the abort in `narrow_release` meant `soundness`,
+      # `shard_liveness`, `wide_exclusion`, `aligned_miri` and
+      # `pic_buf_overflow` never ran at all, and their silence was mistaken for
+      # health. With this flag every target reports.
+      - run: cargo +nightly miri test -p rav1d-disjoint-mut --no-fail-fast
         env:
           MIRIFLAGS: ${{ matrix.model.flags }}
 

--- a/benchmarks/miri_guard_move_2026-08-09.meta
+++ b/benchmarks/miri_guard_move_2026-08-09.meta
@@ -1,0 +1,172 @@
+# Miri UB in `rav1d-disjoint-mut` — root cause, reduction, and gate record
+
+    issue      imazen/rav1d-safe#477 (campaign index #455)
+    branch     fix/miri-ub-narrow-release
+    base       main @ b0f70ee
+    host       Apple M4 Pro (8P+4E), macOS, aarch64-apple-darwin
+    toolchain  nightly-aarch64-apple-darwin, miri 0.1.0 (da86f4d072 2026-07-24)
+    date       2026-08-09
+
+Every number below was run on this host on this date. Nothing is extrapolated
+except the one wall-time projection in section 4, which is labelled as a fit and
+shows its two measured points.
+
+--------------------------------------------------------------------------------
+## 1. The failure, reproduced
+
+    cargo +nightly miri test -p rav1d-disjoint-mut --test narrow_release
+
+aborts in ~20 s with the same tag CI run 31292996318 reported:
+
+    error: Undefined Behavior: not granting access to tag <129070> because that
+    would remove [Unique for <5656840>] which is strongly protected
+      --> tests/narrow_release.rs:126:29   (dm.index_mut(SHARED))
+    help: <129070> was created here, as the root tag for alloc42080
+      --> tests/narrow_release.rs:78:40    (vec![0u8; LEN])
+    help: <5656840> is this argument
+      --> tests/narrow_release.rs:141:21   (drop(g))
+    note: this is on thread `unnamed-5`
+
+Read it off the spans: the PROTECTED tag is the `&mut [u8]` inside the guard
+that thread `unnamed-5` moved by value into `drop`; the ACCESSING tag is the
+buffer's root, used by ANOTHER thread's `index_mut` for the same 8 bytes.
+
+--------------------------------------------------------------------------------
+## 2. Test construction or library? — the three-arm reduction
+
+7 threads, all contending `4096..4104` on a 32 KiB `DisjointMut<Vec<u8>>`,
+400 rounds each. The arms differ ONLY in how the guard is destroyed.
+
+    arm                          SB              TB                 granted/refused
+    -------------------------------------------------------------------------------
+    A  drop(g)      by-value     UB              UB (seeds 1,2,3;   2239 / 561
+                                                     seed 0 clean)
+    B  scope exit   no move      clean           clean              2228 / 572
+    C  eat(g)       by-value     UB              UB (seed 0)        2226 / 574
+
+The tracker grants and refuses identically in all three, so the tracker is not
+the variable — the MOVE is. `drop(g)` is ordinary safe code. **The defect is in
+the library, not in the test.**
+
+Shared guard, same reduction with 5 readers + 2 writers on one range (readers
+coexist, so a reader's release overlaps other readers' live borrows):
+
+    D  index()+drop(g)           UB              UB                 2635 / 165
+       (SB: `[SharedReadOnly for <650566>] which is strongly protected`
+        TB: `write access through <1135450> ... is forbidden`)
+    E  index(), scope exit       clean           clean              2630 / 170
+
+After the fix all six arms are clean under both models, at unchanged grant
+counts (A 2239/561 SB, 2236/564 TB; B 2228/572; D 2635/165).
+
+TB seed sensitivity, pre-fix arm A, measured not assumed:
+    seed 0  clean      seed 1  UB      seed 2  UB      seed 3  UB
+Post-fix, seeds 1/2/3 all clean.
+
+--------------------------------------------------------------------------------
+## 3. Root cause
+
+A guard is a value. Passing one by value into a call gives the reference it
+carries a PROTECTOR: for the whole call the reference must stay valid and
+nothing may invalidate it. The guard's `Drop` runs inside that call and retires
+the tracker record — which is exactly what authorises another thread to take the
+region and retag those bytes.
+
+`core::cell::RefMut` holds `NonNull<T>` for the same reason:
+
+    // NB: we use a pointer instead of `&'b mut T` to avoid `noalias`
+    // violations, because a `RefMut` argument doesn't hold exclusivity for its
+    // whole scope, only until it drops.
+
+For `DisjointMut` it is stronger than `noalias`: another thread genuinely
+retags.
+
+Fix: `slice: *mut V` / `*const V`, reference materialised in `Deref`/`DerefMut`.
+Four `unsafe impl`s restore the auto-traits the reference fields derived.
+
+Auto-trait parity, compiled against BOTH revisions:
+
+    probe                                                    main      HEAD
+    ---------------------------------------------------------------------
+    Send/Sync DisjointMutGuard<'_, Vec<u8>, [u8]>            compiles  compiles
+    Send/Sync DisjointImmutGuard<'_, Vec<u8>, [u8]>          compiles  compiles
+    Send      DisjointMutGuard<'_, Vec<u8>, *const u8>       E0277     E0277
+    Send      DisjointMutGuard<'_, Vec<*const u8>, [u8]>     E0277     E0277
+    Send      DisjointImmutGuard<'_, Vec<u8>, Cell<u8>>      E0277     E0277
+
+Neither wider nor narrower.
+
+--------------------------------------------------------------------------------
+## 4. Why `narrow_release` gets a `cfg(miri)` round count
+
+Two-point wall fit of the test itself under Stacked Borrows, `total = a + b*rounds`:
+
+    rounds   wall
+      100    23.12 s
+      400    92.19 s
+    -> b = 0.230 s/round, a = 0.10 s
+    -> 200_000 rounds = ~12.8 hours PER MEMORY MODEL   (projection, labelled)
+
+The Miri leg could never have finished it. Miri rounds = 400; the NATIVE run
+keeps 200_000 unchanged. Liveness at 400 Miri rounds:
+
+    Stacked Borrows   private_ok 8400   shared_ok 1846   refused 954
+    Tree Borrows      private_ok 8400   shared_ok 1862   refused 938
+
+Floors 4_000 / 700 are 48% / 25% of attempts, against the native floors'
+0.24% / 0.07% — proportionally tighter, not looser.
+
+--------------------------------------------------------------------------------
+## 5. Gate teeth (mutation-verified)
+
+    plant                                    gate                     result
+    -------------------------------------------------------------------------
+    pre-fix guards (git show main:lib.rs)    guard_move_release SB    FAILS (UB)
+    pre-fix guards                           guard_move_release TB    FAILS (UB)
+    pre-fix guards                           narrow_release SB @400   FAILS (UB)
+    pre-fix guards                           narrow_release TB @400   PASSES (*)
+    live_mask `allocated<=1` -> `<=2`        narrow_release native    FAILS, witnesses=1, 2.52 s
+    live_mask `<=2`                          rest of suite            all green
+    active() -> `&self.shards[..1]`          wide_exclusion __probe_wide  FAILS, 418 violations
+    4af62ae TOCTOU deleted from add_contended wide_exclusion __probe_wide FAILS 5/5, 929..1674
+    4af62ae TOCTOU deleted from add only     wide_exclusion __probe_wide  PASSES 8/8 (**)
+
+    (*)  seeds 0 and 1 tried. The shorter Miri round count costs narrow_release
+         its Tree-Borrows teeth for this defect; guard_move_release covers it.
+    (**) the wide registrant holds every shard lock while publishing, so a narrow
+         registrant in that window fails `try_lock` by construction and lands in
+         `add_contended`. The fast-path half of that hazard is NOT gated here.
+
+Every plant restored from a byte-level snapshot; `shasum -a 256 -c` OK and
+`git diff` empty against `main` in each case.
+
+`forbid(unsafe_code)` proved ACTIVELY in the parent crate: an `unsafe` block
+planted at `src/lib.rs:11` fails the default-feature build with
+`error: usage of an 'unsafe' block`. Restored, `git diff` empty.
+
+--------------------------------------------------------------------------------
+## 6. Corpus
+
+`examples/md5_inventory` (this branch adds `--threads`), per meson group, set-
+diffed BY NAME with the ACTUAL md5 in the value.
+
+    threads=1   main 768 rows / HEAD 768 rows
+                only-in-main 0, only-in-HEAD 0, differing values 0
+                statuses: PASS 766, SKIP 2  (both sides)
+    vs benchmarks/aarch64_md5_fixes_2026-08-07_final.tsv.zst
+                only-in-either 0, differing values 0
+
+    threads=8   main 755 rows / HEAD 755 rows
+                only-in-main 0, only-in-HEAD 0, differing values 0
+                statuses: PASS 753, SKIP 2  (both sides)
+
+The 13 missing rows at threads=8 are the film-grain groups: `md5_inventory
+--threads 8` ABORTS at the first film-grain vector, identically on `main` and on
+this branch (rc=101, same 13 vectors lost). Pre-existing whole-plane
+`full_guard_mut` in `src/safe_simd/filmgrain_arm.rs:1550` — filed as #479, not
+touched here.
+
+--------------------------------------------------------------------------------
+## 7. Performance
+
+See section 7b (appended after the interleaved run).

--- a/benchmarks/miri_guard_move_2026-08-09.meta
+++ b/benchmarks/miri_guard_move_2026-08-09.meta
@@ -233,9 +233,9 @@ floors scaled with it so neither side can silently degenerate.
     shard_liveness::exhaustive_pairs...              331_776 pr  3.7-7.4 h       11_236 pr, 991 s
                                                        (0.85 s)   (proj; ran 53
                                                                    min, unfinished)
-    wide_exclusion::a_wide_borrow_excludes...        60_000 rd   killed at 10    300 rd,  182 s
-                                                       (0.05 s)   min, unfinished,
-                                                                  both models
+    wide_exclusion::a_wide_borrow_excludes...        60_000 rd   killed at 10    300 rd,   92 s
+                                                       (0.05 s)   min, unfinished, (+ 2 narrow
+                                                                  both models      contenders)
 
 `shard_liveness`'s cost is `DisjointMut::new(vec![0u8; 24 KiB])` per pair — it
 has to be fresh, a poisoned tracker would mask later results — so every pair is
@@ -250,7 +250,25 @@ take the wide path and lock all 128 shards.
 
 `wide_exclusion`'s cost is the same thing from the other end: every round takes a
 whole-buffer borrow of an 8 MiB instance, which promotes to the wide path and
-locks every shard, against six contending narrow threads.
+locks every shard, against contending narrow threads.
+
+It also needed a SECOND Miri-only change, and the way it surfaced is worth
+recording. At the native six narrow contenders, the Tree Borrows leg failed:
+
+    the wide registrant was refused almost every round (3); the race window
+    was never exercised
+
+That is not UB and not a regression — it is the anti-vacuity assertion doing
+exactly its job, because Miri's scheduler starves the wide registrant (3 grants
+in 300 rounds, against a floor of ROUNDS/100). The fix is to stop starving the
+wide side, NOT to lower the floor: `NARROW_THREADS` is 2 under Miri, 6 natively,
+and every assertion is byte-identical. After: 91.9 s SB / 91.5 s TB, both pass,
+both floors met — and half the cost of the six-contender run (181.7 s).
+
+Note this is the same failure mode the workflow already documents for the
+`__probe_count` instrumented leg. A gate whose liveness assertions are
+scheduling-sensitive will fire under any scheduler change; the response is
+always to restore the exercise, never to lower the bar.
 
 **Conclusion: `disjoint-mut CI`'s Miri leg has never been green and could not
 have been, whatever the guards did.** Before 2026-08-09 it aborted on the

--- a/benchmarks/miri_guard_move_2026-08-09.meta
+++ b/benchmarks/miri_guard_move_2026-08-09.meta
@@ -277,7 +277,48 @@ guard-move UB (#477) and never reached these. The anti-vacuity evidence for
 `wide-path-gate` job (`--features __probe_wide`), which is untouched.
 
 --------------------------------------------------------------------------------
-## 9. Reproducing
+## 9. The whole Miri suite, per test binary, per model
+
+Each binary run SEPARATELY, because Miri aborts the process on the first UB and
+cargo stops at the first failing target — the reason `soundness`,
+`shard_liveness`, `wide_exclusion`, `aligned_miri` and `pic_buf_overflow` never
+executed at all in the failing CI run. (`--no-fail-fast` is now on the workflow's
+Miri leg for the same reason.)
+
+    binary                  Stacked Borrows              Tree Borrows
+    -----------------------------------------------------------------------------
+    aligned_miri            ok    0 tests      0.04 s    ok    0 tests    0.04 s
+    pic_buf_overflow        ok    0 tests      0.03 s    ok    0 tests    0.03 s
+    soundness               ok   25 tests      9.59 s    ok   25 tests    9.69 s
+    wide_exclusion          ok    1 test     181.66 s    FAILED (*)     180.44 s
+    narrow_release          ok    1 test      92.76 s    ok    1 test    92.95 s
+    guard_move_release      ok    2 tests    110.99 s    ok    2 tests  112.19 s
+    shard_liveness          ok    5 tests    992.69 s    ok    5 tests  993.11 s
+    lib                     ok   26 tests   1488.78 s    STILL RUNNING (**)
+
+    (*)  NOT UB, and NOT the shipped configuration. This leg ran the
+         SIX-contender `wide_exclusion`; its anti-vacuity assertion fired
+         ("the wide registrant was refused almost every round (3)") because
+         Miri's scheduler starves the wide side. Fixed by cutting Miri to two
+         narrow contenders — assertions untouched — and re-run on BOTH models
+         afterwards: ok in 91.88 s (SB) and 91.45 s (TB). That pair is the
+         shipped number; the 181.66/180.44 above are the pre-fix six-contender
+         runs.
+    (**) `tracker_shard::tests::threaded_churn_leaks_no_slots` under Tree
+         Borrows. Its Stacked-Borrows twin finished the whole lib in 1488.78 s
+         — which independently matches the 1489 s CI reported for the lib on
+         `main` — but Tree Borrows was past 83 minutes on this one test when
+         this record was written, and had not finished. NOT reported as green.
+         CI run 31325959025 is the authority for it.
+
+**Total per model at the shipped configuration: ~46 minutes** (0.04 + 0.03 +
+9.6 + 91.9 + 92.8 + 111 + 993 + 1489 s), against "cannot finish" before.
+
+**No UB anywhere.** Every failure in this table is a liveness assertion, and the
+one that fired is documented above with its fix.
+
+--------------------------------------------------------------------------------
+## 10. Reproducing
 
     # the UB, on main
     git checkout main

--- a/benchmarks/miri_guard_move_2026-08-09.meta
+++ b/benchmarks/miri_guard_move_2026-08-09.meta
@@ -81,8 +81,11 @@ region and retag those bytes.
 For `DisjointMut` it is stronger than `noalias`: another thread genuinely
 retags.
 
-Fix: `slice: *mut V` / `*const V`, reference materialised in `Deref`/`DerefMut`.
-Four `unsafe impl`s restore the auto-traits the reference fields derived.
+Fix: `slice: NonNull<V>` in both guards, reference materialised in
+`Deref`/`DerefMut`. Four `unsafe impl`s restore the auto-traits the reference
+fields derived, and `PhantomData<(&'a mut V, &'a DisjointMut<T>)>` restores the
+lifetime and the invariance in `V` that `NonNull` (covariant) would otherwise
+drop. The first cut used a bare `*mut V`; section 7 is why it does not ship.
 
 Auto-trait parity, compiled against BOTH revisions:
 
@@ -94,7 +97,8 @@ Auto-trait parity, compiled against BOTH revisions:
     Send      DisjointMutGuard<'_, Vec<*const u8>, [u8]>     E0277     E0277
     Send      DisjointImmutGuard<'_, Vec<u8>, Cell<u8>>      E0277     E0277
 
-Neither wider nor narrower.
+Neither wider nor narrower. Re-run identically against the shipped `NonNull`
+cut: same five results.
 
 --------------------------------------------------------------------------------
 ## 4. Why `narrow_release` gets a `cfg(miri)` round count
@@ -156,17 +160,83 @@ diffed BY NAME with the ACTUAL md5 in the value.
     vs benchmarks/aarch64_md5_fixes_2026-08-07_final.tsv.zst
                 only-in-either 0, differing values 0
 
-    threads=8   main 755 rows / HEAD 755 rows
+    threads=8, excluding film_grain (see below)
+                main 755 rows / HEAD 755 rows
                 only-in-main 0, only-in-HEAD 0, differing values 0
                 statuses: PASS 753, SKIP 2  (both sides)
 
-The 13 missing rows at threads=8 are the film-grain groups: `md5_inventory
---threads 8` ABORTS at the first film-grain vector, identically on `main` and on
-this branch (rc=101, same 13 vectors lost). Pre-existing whole-plane
-`full_guard_mut` in `src/safe_simd/filmgrain_arm.rs:1550` — filed as #479, not
-touched here.
+    HEAD threads=1 vs HEAD threads=8, same 755 vectors
+                differing values 0
+                — the tile workers produce the same md5 as the serial path,
+                  which is the property a borrow-tracker change could break and
+                  the single-threaded gate could never see.
+
+**film_grain is excluded from the threads=8 comparison because it cannot be
+run at all.** `md5_inventory --threads 8` dies in the film-grain groups on
+`main` and on this branch alike, and dies NONDETERMINISTICALLY — one run lost
+all 13 film-grain vectors to a process abort at the first one, another got a
+caught ERROR on that vector, cleared the rest of 8-bit, and aborted in 10-bit.
+Pre-existing whole-plane `full_guard_mut` in
+`src/safe_simd/filmgrain_arm.rs:1550`, filed as #479, not touched here.
 
 --------------------------------------------------------------------------------
 ## 7. Performance
 
-See section 7b (appended after the interleaved run).
+`scripts/perf/verify_gap.sh`, rotating arm order inside each cell, two-point
+wall fit at 2 and 20 frames (process startup removed), strict idle gate — the
+foreign>25%-CPU count was **0 in every committed cell of both runs**, and no
+cell was discarded. No `nice` on any timed run, no `-C target-cpu=native`.
+Arms staged as separate binaries built from the two worktrees.
+
+Run A (n=7, arms base/head):
+
+    vec              t   base med ms/f   head/base med   [min,    max]
+    v4k_8tile        1        318.50        1.0123      [1.0003, 1.0351]
+    v4k_8tile        8         67.22        0.9975      [0.9806, 1.0246]
+    v4k_8tile_10b    8         72.78        0.9912      [0.9736, 1.0023]
+
+t=1 came back +1.2% with EVERY paired ratio above 1.0 (min 1.0003). Small, but
+the band excludes 1.000 and 7/7 agree in sign, so it is not noise. Cause: the
+first cut of the fix used a bare `*mut V`, and a reference field carries
+`nonnull` (and the niche) into every load of the guard that a raw pointer does
+not.
+
+Run B (n=9, three arms: base / head = bare `*mut V` / head2 = `NonNull` +
+`#[inline(always)]` on the three `Deref`/`DerefMut` bodies):
+
+    vec              t   base med ms/f   head/base med          head2/base med
+    v4k_8tile        1        318.44   1.0114 [1.0009,1.0337]   1.0005 [0.9331,1.0119]
+    v4k_8tile        8         67.44   1.0034 [0.9712,1.0404]   0.9926 [0.9715,1.0358]
+    v4k_8tile_10b    8         72.89   0.9838 [0.9754,1.0116]   0.9933 [0.9808,1.0108]
+
+Run B REPRODUCES the t=1 regression on `head` (1.0114, min 1.0009) and shows
+`head2` recovering it (1.0005, band straddling 1.000). Both t=8 cells are null
+for both arms in both runs. **`head2` is what ships.**
+
+Honest caveat: `NonNull` and `#[inline(always)]` were changed together and
+measured together. No per-knob attribution is claimed — see the AGENT_BRIEF
+note about strongly super-additive pairs, which is a reason to distrust
+splitting a measured pair post hoc, not a licence to assume additivity.
+
+--------------------------------------------------------------------------------
+## 8. Reproducing
+
+    # the UB, on main
+    git checkout main
+    cargo +nightly miri test -p rav1d-disjoint-mut --test narrow_release
+    MIRIFLAGS=-Zmiri-tree-borrows cargo +nightly miri test -p rav1d-disjoint-mut \
+        --test guard_move_release        # needs this branch's test file
+
+    # the gate, on this branch
+    cargo +nightly miri test -p rav1d-disjoint-mut --test guard_move_release
+    MIRIFLAGS=-Zmiri-tree-borrows cargo +nightly miri test -p rav1d-disjoint-mut \
+        --test guard_move_release
+
+    # corpus
+    cargo build --release --example md5_inventory
+    ./target/release/examples/md5_inventory --threads 1 > t1.tsv
+    ./target/release/examples/md5_inventory --threads 8 --group 8-bit/data/meson.build
+
+    # perf
+    BIN=<staged bins> ARMS="base head2" CELLS="v4k_8tile:1 v4k_8tile:8" \
+        scripts/perf/verify_gap.sh out.tsv 9

--- a/benchmarks/miri_guard_move_2026-08-09.meta
+++ b/benchmarks/miri_guard_move_2026-08-09.meta
@@ -236,6 +236,9 @@ floors scaled with it so neither side can silently degenerate.
     wide_exclusion::a_wide_borrow_excludes...        60_000 rd   killed at 10    300 rd,   92 s
                                                        (0.05 s)   min, unfinished, (+ 2 narrow
                                                                   both models      contenders)
+    lib threaded_churn_leaks_no_slots (50_000)       0.02 s for   SB 1488.8 s,    1_500 + 1_000:
+      + threaded_disjoint_is_clean   (20_000)        all 26        TB TIMED OUT    66.8 s SB
+                                                                   at 7_200 s      66.7 s TB
 
 `shard_liveness`'s cost is `DisjointMut::new(vec![0u8; 24 KiB])` per pair — it
 has to be fresh, a poisoned tracker would mask later results — so every pair is
@@ -294,7 +297,7 @@ Miri leg for the same reason.)
     narrow_release          ok    1 test      92.76 s    ok    1 test    92.95 s
     guard_move_release      ok    2 tests    110.99 s    ok    2 tests  112.19 s
     shard_liveness          ok    5 tests    992.69 s    ok    5 tests  993.11 s
-    lib                     ok   26 tests   1488.78 s    STILL RUNNING (**)
+    lib                     ok   26 tests   1488.78 s    TIMED OUT (**)
 
     (*)  NOT UB, and NOT the shipped configuration. This leg ran the
          SIX-contender `wide_exclusion`; its anti-vacuity assertion fired
@@ -304,18 +307,27 @@ Miri leg for the same reason.)
          afterwards: ok in 91.88 s (SB) and 91.45 s (TB). That pair is the
          shipped number; the 181.66/180.44 above are the pre-fix six-contender
          runs.
-    (**) `tracker_shard::tests::threaded_churn_leaks_no_slots` under Tree
-         Borrows. Its Stacked-Borrows twin finished the whole lib in 1488.78 s
-         — which independently matches the 1489 s CI reported for the lib on
-         `main` — but Tree Borrows was past 83 minutes on this one test when
-         this record was written, and had not finished. NOT reported as green.
-         CI run 31325959025 is the authority for it.
+    (**) Hit the harness's 7_200 s cap with 22 of 26 done, inside
+         `tracker_shard::tests::threaded_disjoint_is_clean` (and having spent
+         ~83 min on `threaded_churn_leaks_no_slots` before it). rc=124, i.e.
+         `timeout`, NOT a failure. Its Stacked-Borrows twin did the same 26
+         tests in 1488.78 s — which independently matches the 1489 s CI
+         reported for the lib on `main`. So Tree Borrows is >5x slower on
+         exactly those two loops (8 threads x 50_000 and x 20_000 add/remove
+         pairs, the first all on ONE shard).
 
-**Total per model at the shipped configuration: ~46 minutes** (0.04 + 0.03 +
-9.6 + 91.9 + 92.8 + 111 + 993 + 1489 s), against "cannot finish" before.
+         FOURTH and last blocker, fixed the same way: `cfg(miri)` counts of
+         1_500 and 1_000, native untouched. Re-measured after:
 
-**No UB anywhere.** Every failure in this table is a liveness assertion, and the
-one that fired is documented above with its fix.
+             lib, Stacked Borrows   1488.78 s -> 66.77 s   26/26 ok
+             lib, Tree Borrows       >7200 s  -> 66.72 s   26/26 ok
+
+**Total per model at the shipped configuration: ~23 minutes** (0.04 + 0.03 +
+9.6 + 91.9 + 92.8 + 111 + 993 + 66.8 s), against "cannot finish" before this
+branch — on EITHER model.
+
+**No UB anywhere.** Every failure in this table is a liveness assertion or a
+timeout, and both are documented above with their fixes.
 
 --------------------------------------------------------------------------------
 ## 10. Reproducing

--- a/benchmarks/miri_guard_move_2026-08-09.meta
+++ b/benchmarks/miri_guard_move_2026-08-09.meta
@@ -219,7 +219,47 @@ note about strongly super-additive pairs, which is a reason to distrust
 splitting a measured pair post hoc, not a licence to assume additivity.
 
 --------------------------------------------------------------------------------
-## 8. Reproducing
+## 8. The Miri leg could never have finished, and the UB was only one reason
+
+Item 7 of the brief was "run the WHOLE Miri suite and report every remaining
+failure by name". Doing that turned up two more tests that cannot run under Miri
+at all. Both got the same treatment as `narrow_release`: NATIVE workload
+unchanged, `cfg(miri)` workload cut to something that terminates, anti-vacuity
+floors scaled with it so neither side can silently degenerate.
+
+    test                                             native      Miri (before)   Miri (after)
+    ------------------------------------------------------------------------------------------
+    narrow_release                                   200_000 rd  ~12.8 h (fit)   400 rd,   92 s
+    shard_liveness::exhaustive_pairs...              331_776 pr  3.7-7.4 h       11_236 pr, 991 s
+                                                       (0.85 s)   (proj; ran 53
+                                                                   min, unfinished)
+    wide_exclusion::a_wide_borrow_excludes...        60_000 rd   killed at 10    300 rd,  182 s
+                                                       (0.05 s)   min, unfinished,
+                                                                  both models
+
+`shard_liveness`'s cost is `DisjointMut::new(vec![0u8; 24 KiB])` per pair — it
+has to be fresh, a poisoned tracker would mask later results — so every pair is
+24_576 emulated zero-writes plus a 128-shard tracker. Two measured rates:
+
+    start list          pairs     Miri wall     per pair
+    [0, 1, 3]           2_916      117.8 s       40 ms
+    the six shipped    11_236      991.2 s       80 ms  (whole binary, 5 tests)
+
+The spread is the mix — the shipped six include offsets whose 20_000-byte `LENS`
+take the wide path and lock all 128 shards.
+
+`wide_exclusion`'s cost is the same thing from the other end: every round takes a
+whole-buffer borrow of an 8 MiB instance, which promotes to the wide path and
+locks every shard, against six contending narrow threads.
+
+**Conclusion: `disjoint-mut CI`'s Miri leg has never been green and could not
+have been, whatever the guards did.** Before 2026-08-09 it aborted on the
+guard-move UB (#477) and never reached these. The anti-vacuity evidence for
+`wide_exclusion` does not depend on its Miri count — that comes from the NATIVE
+`wide-path-gate` job (`--features __probe_wide`), which is untouched.
+
+--------------------------------------------------------------------------------
+## 9. Reproducing
 
     # the UB, on main
     git checkout main

--- a/crates/rav1d-disjoint-mut/AUDIT.md
+++ b/crates/rav1d-disjoint-mut/AUDIT.md
@@ -6,6 +6,33 @@
 
 ## Bugs Found and Fixed
 
+### CRITICAL: guards held a reference across their own release (FIXED 2026-08-09, #477)
+
+**Found after this audit, by CI, not by it.** `DisjointMutGuard` held
+`slice: &'a mut V` and `DisjointImmutGuard` held `slice: &'a V`. Moving a guard
+by value into a call — `drop(g)`, `ManuallyDrop::new(g)`, any `f(g)` — protects
+that reference for the duration of the call; the guard's `Drop` runs inside that
+call and retires the tracker record, which is what lets **another thread** take
+the region and retag those bytes. The protected reference is invalidated
+mid-call. Reachable from safe code.
+
+**Fix:** both guards hold `*mut V` / `*const V` and materialise the reference in
+`Deref`/`DerefMut`. `core::cell::RefMut` holds a `NonNull<T>` for the same
+reason. Four `unsafe impl`s restore the auto-traits the reference fields used to
+derive (verified against both revisions with identical positive and negative
+bound probes).
+
+**Why this audit missed it.** Everything above is about a retag colliding with a
+*concurrent* retag; this one needs a retag to collide with a *protector*, which
+only exists while a guard is IN a call. Nothing in the suite moved a guard by
+value under contention until `tests/narrow_release.rs` (2026-08-08) did — and it
+found it on its first Miri run. Reproduces under both Stacked Borrows and Tree
+Borrows. Gated by `tests/guard_move_release.rs`, which includes scope-exit
+control arms so a future failure that is not about the move is distinguishable.
+
+**Standing lesson:** a Miri arm that only exercises `{ let _g = dm.index_mut(r);
+… }` cannot see this class at all. Concurrency tests must move guards.
+
 ### CRITICAL: Stacked Borrows UB in `Vec<V>::as_mut_ptr` (FIXED)
 
 `(*ptr).as_mut_ptr()` auto-refs to `&mut Vec<V>`, creating a `Unique` retag on the Vec struct allocation. When two threads call `index_mut` for disjoint ranges concurrently, thread A's `Unique` retag conflicts with thread B's `SharedReadOnly` retag from `(*ptr).len()`.
@@ -64,11 +91,11 @@ Docs didn't warn about intermediate `&mut` references causing SB retagging confl
 
 1. **Core overlap tracking** — `BorrowTracker` uses `parking_lot::Mutex` to serialize registration. Registration before reference creation prevents TOCTOU. Poisoning on panic prevents access to potentially corrupted data.
 
-2. **Guard lifecycle** — RAII-based. Drop deregisters. `ManuallyDrop` in `cast_slice`/`cast` correctly transfers borrow ownership.
+2. **Guard lifecycle** — RAII-based. Drop deregisters. `ManuallyDrop` in `cast_slice`/`cast` correctly transfers borrow ownership. **Amended 2026-08-09:** the guard must hold the region as a POINTER, never as a reference — see the first entry under "Bugs Found and Fixed". Reverting that is UB, not a style choice.
 
 3. **Sealed trait** — `AsMutPtr` sealed via private supertrait. External types go through `unsafe ExternalAsMutPtr`. `Copy` bound on `Target` prevents torn reads.
 
-4. **Send/Sync bounds** — Correct: `T: Send` for `Send`, `T: Sync` for `Sync`. Tracker uses `Mutex`.
+4. **Send/Sync bounds** — Correct: `T: Send` for `Send`, `T: Sync` for `Sync`. Tracker uses `Mutex`. **Amended 2026-08-09:** the guards' bounds are now explicit `unsafe impl`s rather than derived, because their region field is a raw pointer. They reproduce the derived bounds exactly; if you touch them, re-run the positive/negative probe pair against the previous revision.
 
 5. **All AsMutPtr impls override `as_mut_slice`** — The default impl (which creates `&T`) is never used. Every concrete type uses reference-free pointer operations.
 

--- a/crates/rav1d-disjoint-mut/CHANGELOG.md
+++ b/crates/rav1d-disjoint-mut/CHANGELOG.md
@@ -13,10 +13,14 @@ All notable changes to `rav1d-disjoint-mut` are documented in this file. Format 
   call and retires the tracker record, which is precisely what lets ANOTHER
   thread take the region and retag those bytes. The protected reference is
   invalidated mid-call. Reachable from safe code, on the release path the
-  whole crate is built around. Both guards hold `*mut V` / `*const V` now and
+  whole crate is built around. Both guards hold `NonNull<V>` now and
   materialise the reference in `Deref`/`DerefMut`, where borrowck bounds it to
   a region in which the guard cannot be dropped — the same reason
-  `core::cell::RefMut` holds a `NonNull<T>`. The four `Send`/`Sync` impls
+  `core::cell::RefMut` holds a `NonNull<T>`. `NonNull` rather than `*mut V`
+  because a reference field carries `nonnull` into every load and a bare raw
+  pointer does not: measured +1.1-1.2% at v4k_8tile t=1 in two independent
+  interleaved runs, recovered to 1.0005 by `NonNull` plus `#[inline(always)]`
+  on the three `Deref`/`DerefMut` bodies. The four `Send`/`Sync` impls
   restore, exactly, what the compiler derived from the reference fields
   (verified by compiling the same positive and negative bound probes against
   both revisions), so there is no auto-trait change. Found by

--- a/crates/rav1d-disjoint-mut/CHANGELOG.md
+++ b/crates/rav1d-disjoint-mut/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `rav1d-disjoint-mut` are documented in this file. Format 
 
 ## [Unreleased]
 
+### Fixed
+- **Soundness: moving a guard by value was UB while another thread held the
+  same region.** `DisjointMutGuard`/`DisjointImmutGuard` carried the borrowed
+  region as `&'a mut V` / `&'a V`. Passing a guard by value into a call —
+  `drop(g)` above all — gives that reference a *protector*, which requires it
+  to stay valid for the whole call; but the guard's `Drop` runs inside that
+  call and retires the tracker record, which is precisely what lets ANOTHER
+  thread take the region and retag those bytes. The protected reference is
+  invalidated mid-call. Reachable from safe code, on the release path the
+  whole crate is built around. Both guards hold `*mut V` / `*const V` now and
+  materialise the reference in `Deref`/`DerefMut`, where borrowck bounds it to
+  a region in which the guard cannot be dropped — the same reason
+  `core::cell::RefMut` holds a `NonNull<T>`. The four `Send`/`Sync` impls
+  restore, exactly, what the compiler derived from the reference fields
+  (verified by compiling the same positive and negative bound probes against
+  both revisions), so there is no auto-trait change. Found by
+  `tests/narrow_release.rs` under Miri (CI run 31292996318); reproduces under
+  **both** Stacked Borrows and Tree Borrows; gated by the new
+  `tests/guard_move_release.rs`, which fails under both models against the old
+  guards. No change to the tracker, and no bitstream change: 766/766
+  dav1d-test-data vectors byte-identical at `--threads 1`, set-diffed by name
+  with the MD5 in the value.
+
 ### Added
 - **Overlap panics now report the EXISTING borrow's registration site.**
   `BorrowSlots` records `&'static Location` per active borrow, and

--- a/crates/rav1d-disjoint-mut/src/lib.rs
+++ b/crates/rav1d-disjoint-mut/src/lib.rs
@@ -76,6 +76,7 @@ use core::ops::RangeInclusive;
 use core::ops::RangeTo;
 use core::ops::RangeToInclusive;
 use core::ptr;
+use core::ptr::NonNull;
 use core::ptr::addr_of_mut;
 #[cfg(feature = "zerocopy")]
 use zerocopy::FromBytes;
@@ -272,7 +273,11 @@ pub struct DisjointMutGuard<'a, T: ?Sized + AsMutPtr, V: ?Sized> {
     /// Raw by design — see the type-level docs. Always dereferenceable for the
     /// guard's whole life: the registration that made it exclusive is retired
     /// only in `Drop`.
-    slice: *mut V,
+    ///
+    /// `NonNull`, not `*mut V`: a reference field carried `nonnull` (and the
+    /// niche) into every load, and a bare raw pointer drops both. Measured, so
+    /// not a guess — see `benchmarks/miri_guard_move_2026-08-09.meta` §7.
+    slice: NonNull<V>,
 
     /// Carries everything the `&'a mut V` field used to supply except the
     /// reference itself: the lifetime, invariance in `V`, and the auto-trait
@@ -328,15 +333,15 @@ impl<'a, T: AsMutPtr> DisjointMutGuard<'a, T, [u8]> {
         // `ManuallyDrop`, so nothing has retired it), which is what makes this
         // region exclusively ours. The reference does not outlive the cast: it
         // is consumed by `mut_from_bytes` and only its address is kept.
-        let raw = old_guard.slice;
-        let bytes: &mut [u8] = unsafe { &mut *raw };
+        let mut raw = old_guard.slice;
+        let bytes: &mut [u8] = unsafe { raw.as_mut() };
         // Both are pure reads of values already live, so LLVM sinks them into
         // the cold arm; they exist only to give `cast_slice_failed` something
         // to report without a `CastError` on the hot path's frame.
         let (n, addr) = (bytes.len(), bytes.as_ptr() as usize);
         DisjointMutGuard {
             slice: match <[V]>::mut_from_bytes(bytes) {
-                Ok(v) => ptr::from_mut(v),
+                Ok(v) => NonNull::from(v),
                 Err(_) => cast_slice_failed::<V>(n, addr),
             },
             phantom: PhantomData,
@@ -349,10 +354,10 @@ impl<'a, T: AsMutPtr> DisjointMutGuard<'a, T, [u8]> {
     fn cast<V: IntoBytes + FromBytes + KnownLayout>(self) -> DisjointMutGuard<'a, T, V> {
         let old_guard = ManuallyDrop::new(self);
         // SAFETY: as in `cast_slice`.
-        let raw = old_guard.slice;
-        let bytes: &mut [u8] = unsafe { &mut *raw };
+        let mut raw = old_guard.slice;
+        let bytes: &mut [u8] = unsafe { raw.as_mut() };
         DisjointMutGuard {
-            slice: ptr::from_mut(V::mut_from_bytes(bytes).unwrap()),
+            slice: NonNull::from(V::mut_from_bytes(bytes).unwrap()),
             phantom: PhantomData,
             parent: old_guard.parent,
             borrow_id: old_guard.borrow_id,
@@ -385,20 +390,22 @@ unsafe impl<T: ?Sized + AsMutPtr + Sync, V: ?Sized + Sync> Sync for DisjointImmu
 impl<'a, T: ?Sized + AsMutPtr, V: ?Sized> Deref for DisjointMutGuard<'a, T, V> {
     type Target = V;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         // SAFETY: the registration that makes this region exclusively ours is
         // live for as long as the guard is, and it is retired only in `Drop`.
         // Borrowck ties the result to `&self`, so the guard cannot be dropped
         // or moved while the reference exists.
-        unsafe { &*self.slice }
+        unsafe { self.slice.as_ref() }
     }
 }
 
 impl<'a, T: ?Sized + AsMutPtr, V: ?Sized> DerefMut for DisjointMutGuard<'a, T, V> {
+    #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
         // SAFETY: as in `deref`, and the borrow is a mutable registration, so
         // no other live borrow overlaps this region.
-        unsafe { &mut *self.slice }
+        unsafe { self.slice.as_mut() }
     }
 }
 
@@ -411,7 +418,8 @@ impl<'a, T: ?Sized + AsMutPtr, V: ?Sized> DerefMut for DisjointMutGuard<'a, T, V
 /// region mutably. Same defect, same fix; `core::cell::Ref` holds a
 /// `NonNull<T>` for the same reason.
 pub struct DisjointImmutGuard<'a, T: ?Sized + AsMutPtr, V: ?Sized> {
-    slice: *const V,
+    /// `NonNull`, not `*const V` — see [`DisjointMutGuard::slice`].
+    slice: NonNull<V>,
 
     /// See [`DisjointMutGuard::phantom`]. `&'a V` here, so `V: Sync` is what
     /// this guard needs to be `Send` — exactly what the reference field gave.
@@ -429,13 +437,13 @@ impl<'a, T: AsMutPtr> DisjointImmutGuard<'a, T, [u8]> {
         // SAFETY: the borrow is still registered (the old guard is in
         // `ManuallyDrop`), so no mutable borrow overlaps this region.
         let raw = old_guard.slice;
-        let bytes: &[u8] = unsafe { &*raw };
+        let bytes: &[u8] = unsafe { raw.as_ref() };
         // See `cast_slice_failed`: the `CastError` is what puts a 112-byte
         // frame on this function's success path.
         let (n, addr) = (bytes.len(), bytes.as_ptr() as usize);
         DisjointImmutGuard {
             slice: match <[V]>::ref_from_bytes(bytes) {
-                Ok(v) => ptr::from_ref(v),
+                Ok(v) => NonNull::from(v),
                 Err(_) => cast_slice_failed::<V>(n, addr),
             },
             phantom: PhantomData,
@@ -449,9 +457,9 @@ impl<'a, T: AsMutPtr> DisjointImmutGuard<'a, T, [u8]> {
         let old_guard = ManuallyDrop::new(self);
         // SAFETY: as in `cast_slice`.
         let raw = old_guard.slice;
-        let bytes: &[u8] = unsafe { &*raw };
+        let bytes: &[u8] = unsafe { raw.as_ref() };
         DisjointImmutGuard {
-            slice: ptr::from_ref(V::ref_from_bytes(bytes).unwrap()),
+            slice: NonNull::from(V::ref_from_bytes(bytes).unwrap()),
             phantom: PhantomData,
             parent: old_guard.parent,
             borrow_id: old_guard.borrow_id,
@@ -462,11 +470,12 @@ impl<'a, T: AsMutPtr> DisjointImmutGuard<'a, T, [u8]> {
 impl<'a, T: ?Sized + AsMutPtr, V: ?Sized> Deref for DisjointImmutGuard<'a, T, V> {
     type Target = V;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         // SAFETY: the shared registration is live for as long as the guard is
         // and is retired only in `Drop`, so no mutable borrow overlaps this
         // region while the returned reference exists.
-        unsafe { &*self.slice }
+        unsafe { self.slice.as_ref() }
     }
 }
 
@@ -758,7 +767,9 @@ impl<T: ?Sized + AsMutPtr> DisjointMut<T> {
         // The indexed region is guaranteed disjoint from all other active borrows.
         // No reference is created here — see [`DisjointMutGuard`] for why the
         // guard must not carry one.
-        let slice = unsafe { index.get_mut(self.as_mut_slice()) };
+        // SAFETY (NonNull): `get_mut` derives from `as_mut_slice`, which is a
+        // live allocation's pointer, and panics rather than returning null.
+        let slice = unsafe { NonNull::new_unchecked(index.get_mut(self.as_mut_slice())) };
         // Success — disarm the cleanup guard.
         mem::forget(cleanup);
         DisjointMutGuard {
@@ -792,7 +803,8 @@ impl<T: ?Sized + AsMutPtr> DisjointMut<T> {
         let cleanup = BorrowCleanup { parent };
         // SAFETY: The borrow has been registered (or we're unchecked). No
         // reference is created here — see [`DisjointImmutGuard`].
-        let slice = unsafe { index.get_mut(self.as_mut_slice()).cast_const() };
+        // SAFETY (NonNull): as in `index_mut`.
+        let slice = unsafe { NonNull::new_unchecked(index.get_mut(self.as_mut_slice())) };
         mem::forget(cleanup);
         DisjointImmutGuard {
             slice,

--- a/crates/rav1d-disjoint-mut/src/lib.rs
+++ b/crates/rav1d-disjoint-mut/src/lib.rs
@@ -238,10 +238,47 @@ impl<T: ?Sized + AsMutPtr> Drop for BorrowCleanup<'_, T> {
     }
 }
 
+/// A live mutable borrow of one region.
+///
+/// # Why the region is held as a POINTER and not as `&'a mut V`
+///
+/// A guard is a value, so safe code can move it: `drop(g)`, `f(g)`,
+/// `ManuallyDrop::new(g)`, returning it. Rust's aliasing model gives every
+/// reference passed **by value into a call** a *protector* — for the whole of
+/// that call the reference must stay valid, and nothing may invalidate it.
+///
+/// The guard's `Drop` runs at the end of exactly such a call, and it retires
+/// the tracker record. Retiring is what authorises **another thread** to take
+/// the same region and create its own `&mut` over those bytes — which
+/// invalidates ours while the protector is still in force. That is UB, and it
+/// is reachable from safe code: `drop(g)` is all it takes.
+///
+/// A raw pointer has no protector, so moving the guard by value carries no
+/// claim over the buffer. The reference is materialised in [`Deref`] /
+/// [`DerefMut`], where borrowck bounds it to a region in which the guard cannot
+/// be dropped.
+///
+/// This is precisely why `core::cell::RefMut` holds a `NonNull<T>`; its comment
+/// reads *"we use a pointer instead of `&'b mut T` to avoid `noalias`
+/// violations, because a `RefMut` argument doesn't hold exclusivity for its
+/// whole scope, only until it drops."* `DisjointMut`'s cross-thread release
+/// makes the same statement sharper: for us it is not only `noalias`, another
+/// thread is genuinely retagging the bytes.
+///
+/// Found 2026-08-09 by `tests/narrow_release.rs` under Miri; it reproduces
+/// under **both** Stacked Borrows and Tree Borrows. Gated by
+/// `tests/guard_move_release.rs`.
 pub struct DisjointMutGuard<'a, T: ?Sized + AsMutPtr, V: ?Sized> {
-    slice: &'a mut V,
+    /// Raw by design — see the type-level docs. Always dereferenceable for the
+    /// guard's whole life: the registration that made it exclusive is retired
+    /// only in `Drop`.
+    slice: *mut V,
 
-    phantom: PhantomData<&'a DisjointMut<T>>,
+    /// Carries everything the `&'a mut V` field used to supply except the
+    /// reference itself: the lifetime, invariance in `V`, and the auto-trait
+    /// bounds (`Send` iff `V: Send`, `Sync` iff `V: Sync`), which a bare
+    /// `*mut V` would otherwise drop on the floor.
+    phantom: PhantomData<(&'a mut V, &'a DisjointMut<T>)>,
 
     /// Reference to parent for borrow removal on drop.
     /// `None` when parent was created with `dangerously_unchecked`.
@@ -286,18 +323,23 @@ impl<'a, T: AsMutPtr> DisjointMutGuard<'a, T, [u8]> {
     fn cast_slice<V: IntoBytes + FromBytes + KnownLayout>(self) -> DisjointMutGuard<'a, T, [V]> {
         // We don't want to drop the old guard, because we aren't changing or
         // removing the borrow from parent here.
-        let mut old_guard = ManuallyDrop::new(self);
-        let bytes = mem::take(&mut old_guard.slice);
+        let old_guard = ManuallyDrop::new(self);
+        // SAFETY: the borrow is still registered (the old guard is in
+        // `ManuallyDrop`, so nothing has retired it), which is what makes this
+        // region exclusively ours. The reference does not outlive the cast: it
+        // is consumed by `mut_from_bytes` and only its address is kept.
+        let raw = old_guard.slice;
+        let bytes: &mut [u8] = unsafe { &mut *raw };
         // Both are pure reads of values already live, so LLVM sinks them into
         // the cold arm; they exist only to give `cast_slice_failed` something
         // to report without a `CastError` on the hot path's frame.
         let (n, addr) = (bytes.len(), bytes.as_ptr() as usize);
         DisjointMutGuard {
             slice: match <[V]>::mut_from_bytes(bytes) {
-                Ok(v) => v,
+                Ok(v) => ptr::from_mut(v),
                 Err(_) => cast_slice_failed::<V>(n, addr),
             },
-            phantom: old_guard.phantom,
+            phantom: PhantomData,
             parent: old_guard.parent,
             borrow_id: old_guard.borrow_id,
         }
@@ -305,35 +347,75 @@ impl<'a, T: AsMutPtr> DisjointMutGuard<'a, T, [u8]> {
 
     #[inline] // Inline to see alignment to potentially elide checks.
     fn cast<V: IntoBytes + FromBytes + KnownLayout>(self) -> DisjointMutGuard<'a, T, V> {
-        let mut old_guard = ManuallyDrop::new(self);
-        let bytes = mem::take(&mut old_guard.slice);
+        let old_guard = ManuallyDrop::new(self);
+        // SAFETY: as in `cast_slice`.
+        let raw = old_guard.slice;
+        let bytes: &mut [u8] = unsafe { &mut *raw };
         DisjointMutGuard {
-            slice: V::mut_from_bytes(bytes).unwrap(),
-            phantom: old_guard.phantom,
+            slice: ptr::from_mut(V::mut_from_bytes(bytes).unwrap()),
+            phantom: PhantomData,
             parent: old_guard.parent,
             borrow_id: old_guard.borrow_id,
         }
     }
 }
 
+// A raw pointer field is `!Send` and `!Sync`, and `PhantomData` cannot argue it
+// back. These four impls RESTORE, exactly, what the compiler derived while the
+// field was `&'a mut V` / `&'a V` — dropping them would be a silent semver break
+// for anything that moves a guard between threads.
+//
+// SAFETY (all four): the guard is a `Copy` pointer plus `Option<&DisjointMut<T>>`
+// plus a `u64` id. Sending or sharing it is sending or sharing exactly
+// `&'a mut V` (resp. `&'a V`) and `&'a DisjointMut<T>`, whose own auto-trait
+// rules are reproduced verbatim in the bounds below:
+//
+// * `&mut V: Send` iff `V: Send`; `&mut V: Sync` iff `V: Sync`;
+// * `&V: Send` iff `V: Sync`;   `&V: Sync` iff `V: Sync`;
+// * `&DisjointMut<T>: Send`/`Sync` iff `DisjointMut<T>: Sync`, which the impl
+//   above grants for `T: AsMutPtr + Sync`.
+//
+// The tracker registration the guard names is shared state either way, and it is
+// already `Send + Sync` (`BorrowTracker`).
+unsafe impl<T: ?Sized + AsMutPtr + Sync, V: ?Sized + Send> Send for DisjointMutGuard<'_, T, V> {}
+unsafe impl<T: ?Sized + AsMutPtr + Sync, V: ?Sized + Sync> Sync for DisjointMutGuard<'_, T, V> {}
+unsafe impl<T: ?Sized + AsMutPtr + Sync, V: ?Sized + Sync> Send for DisjointImmutGuard<'_, T, V> {}
+unsafe impl<T: ?Sized + AsMutPtr + Sync, V: ?Sized + Sync> Sync for DisjointImmutGuard<'_, T, V> {}
+
 impl<'a, T: ?Sized + AsMutPtr, V: ?Sized> Deref for DisjointMutGuard<'a, T, V> {
     type Target = V;
 
     fn deref(&self) -> &Self::Target {
-        self.slice
+        // SAFETY: the registration that makes this region exclusively ours is
+        // live for as long as the guard is, and it is retired only in `Drop`.
+        // Borrowck ties the result to `&self`, so the guard cannot be dropped
+        // or moved while the reference exists.
+        unsafe { &*self.slice }
     }
 }
 
 impl<'a, T: ?Sized + AsMutPtr, V: ?Sized> DerefMut for DisjointMutGuard<'a, T, V> {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        self.slice
+        // SAFETY: as in `deref`, and the borrow is a mutable registration, so
+        // no other live borrow overlaps this region.
+        unsafe { &mut *self.slice }
     }
 }
 
+/// A live shared borrow of one region.
+///
+/// Holds a pointer rather than `&'a V` for the reason spelled out on
+/// [`DisjointMutGuard`]: moving the guard by value into a call — `drop(g)`
+/// above all — would protect the reference for the duration of that call,
+/// while `Drop` inside it retires the record and lets another thread take the
+/// region mutably. Same defect, same fix; `core::cell::Ref` holds a
+/// `NonNull<T>` for the same reason.
 pub struct DisjointImmutGuard<'a, T: ?Sized + AsMutPtr, V: ?Sized> {
-    slice: &'a V,
+    slice: *const V,
 
-    phantom: PhantomData<&'a DisjointMut<T>>,
+    /// See [`DisjointMutGuard::phantom`]. `&'a V` here, so `V: Sync` is what
+    /// this guard needs to be `Send` — exactly what the reference field gave.
+    phantom: PhantomData<(&'a V, &'a DisjointMut<T>)>,
 
     parent: Option<&'a DisjointMut<T>>,
     borrow_id: checked::BorrowId,
@@ -343,17 +425,20 @@ pub struct DisjointImmutGuard<'a, T: ?Sized + AsMutPtr, V: ?Sized> {
 impl<'a, T: AsMutPtr> DisjointImmutGuard<'a, T, [u8]> {
     #[inline]
     fn cast_slice<V: FromBytes + KnownLayout + Immutable>(self) -> DisjointImmutGuard<'a, T, [V]> {
-        let mut old_guard = ManuallyDrop::new(self);
-        let bytes = mem::take(&mut old_guard.slice);
+        let old_guard = ManuallyDrop::new(self);
+        // SAFETY: the borrow is still registered (the old guard is in
+        // `ManuallyDrop`), so no mutable borrow overlaps this region.
+        let raw = old_guard.slice;
+        let bytes: &[u8] = unsafe { &*raw };
         // See `cast_slice_failed`: the `CastError` is what puts a 112-byte
         // frame on this function's success path.
         let (n, addr) = (bytes.len(), bytes.as_ptr() as usize);
         DisjointImmutGuard {
             slice: match <[V]>::ref_from_bytes(bytes) {
-                Ok(v) => v,
+                Ok(v) => ptr::from_ref(v),
                 Err(_) => cast_slice_failed::<V>(n, addr),
             },
-            phantom: old_guard.phantom,
+            phantom: PhantomData,
             parent: old_guard.parent,
             borrow_id: old_guard.borrow_id,
         }
@@ -361,11 +446,13 @@ impl<'a, T: AsMutPtr> DisjointImmutGuard<'a, T, [u8]> {
 
     #[inline]
     fn cast<V: FromBytes + KnownLayout + Immutable>(self) -> DisjointImmutGuard<'a, T, V> {
-        let mut old_guard = ManuallyDrop::new(self);
-        let bytes = mem::take(&mut old_guard.slice);
+        let old_guard = ManuallyDrop::new(self);
+        // SAFETY: as in `cast_slice`.
+        let raw = old_guard.slice;
+        let bytes: &[u8] = unsafe { &*raw };
         DisjointImmutGuard {
-            slice: V::ref_from_bytes(bytes).unwrap(),
-            phantom: old_guard.phantom,
+            slice: ptr::from_ref(V::ref_from_bytes(bytes).unwrap()),
+            phantom: PhantomData,
             parent: old_guard.parent,
             borrow_id: old_guard.borrow_id,
         }
@@ -376,7 +463,10 @@ impl<'a, T: ?Sized + AsMutPtr, V: ?Sized> Deref for DisjointImmutGuard<'a, T, V>
     type Target = V;
 
     fn deref(&self) -> &Self::Target {
-        self.slice
+        // SAFETY: the shared registration is live for as long as the guard is
+        // and is retired only in `Drop`, so no mutable borrow overlaps this
+        // region while the returned reference exists.
+        unsafe { &*self.slice }
     }
 }
 
@@ -666,7 +756,9 @@ impl<T: ?Sized + AsMutPtr> DisjointMut<T> {
         let cleanup = BorrowCleanup { parent };
         // SAFETY: The borrow has been registered (or we're unchecked).
         // The indexed region is guaranteed disjoint from all other active borrows.
-        let slice = unsafe { &mut *index.get_mut(self.as_mut_slice()) };
+        // No reference is created here — see [`DisjointMutGuard`] for why the
+        // guard must not carry one.
+        let slice = unsafe { index.get_mut(self.as_mut_slice()) };
         // Success — disarm the cleanup guard.
         mem::forget(cleanup);
         DisjointMutGuard {
@@ -698,8 +790,9 @@ impl<T: ?Sized + AsMutPtr> DisjointMut<T> {
         };
         let parent = self.tracker.as_ref().map(|_| self);
         let cleanup = BorrowCleanup { parent };
-        // SAFETY: The borrow has been registered (or we're unchecked).
-        let slice = unsafe { &*index.get_mut(self.as_mut_slice()).cast_const() };
+        // SAFETY: The borrow has been registered (or we're unchecked). No
+        // reference is created here — see [`DisjointImmutGuard`].
+        let slice = unsafe { index.get_mut(self.as_mut_slice()).cast_const() };
         mem::forget(cleanup);
         DisjointImmutGuard {
             slice,

--- a/crates/rav1d-disjoint-mut/src/tracker_shard.rs
+++ b/crates/rav1d-disjoint-mut/src/tracker_shard.rs
@@ -2344,7 +2344,13 @@ mod tests {
         for th in 0..8usize {
             let t = Arc::clone(&t);
             hs.push(std::thread::spawn(move || {
-                for _ in 0..50_000usize {
+                // Miri interprets every one of these atomics, and TREE
+                // BORROWS is where it bites: at the native count the whole lib
+                // leg finishes in 1488.78 s under Stacked Borrows but had not
+                // finished this test plus `threaded_disjoint_is_clean` after
+                // 7_200 s under Tree Borrows (2026-08-09, M4 Pro). Native is
+                // unchanged.
+                for _ in 0..if cfg!(miri) { 1_500 } else { 50_000usize } {
                     // Disjoint per thread, all inside block 0 => one shard.
                     let id = t.add_mut(&b(th * 4..th * 4 + 4));
                     t.remove(id);
@@ -2386,7 +2392,9 @@ mod tests {
         for th in 0..8usize {
             let t = Arc::clone(&t);
             hs.push(std::thread::spawn(move || {
-                for i in 0..20_000usize {
+                // See `threaded_churn_leaks_no_slots` for why this is cut
+                // under Miri. Native is unchanged.
+                for i in 0..if cfg!(miri) { 1_000 } else { 20_000usize } {
                     // Interleave the threads across the address space so they
                     // land in the same shards constantly.
                     let base = (i * 8 + th) * 4;

--- a/crates/rav1d-disjoint-mut/tests/guard_move_release.rs
+++ b/crates/rav1d-disjoint-mut/tests/guard_move_release.rs
@@ -1,0 +1,150 @@
+//! Aliasing gate for MOVING a guard: `drop(g)` must not be UB.
+//!
+//! # The defect this exists to catch
+//!
+//! A guard is a value, so safe code may move it into a call — `drop(g)` is the
+//! everyday case, `ManuallyDrop::new(g)` and `f(g)` are others. Rust's aliasing
+//! model gives every reference passed **by value into a call** a *protector*:
+//! for the whole of that call the reference must stay valid and nothing may
+//! invalidate it.
+//!
+//! When the guard carried its region as `&'a mut V` (as it did until
+//! 2026-08-09), that protector covered the buffer bytes — and the guard's
+//! `Drop`, which runs inside that very call, retires the tracker record.
+//! Retiring is exactly what authorises **another thread** to take the region
+//! and retag those bytes for itself. The protected reference is invalidated
+//! mid-call. UB, reachable from safe code, on the release path the whole crate
+//! is built around.
+//!
+//! Both guard kinds had it. Under Stacked Borrows it reads
+//! `not granting access to tag <A> because that would remove [Unique for <B>]`
+//! (`[SharedReadOnly for <B>]` for the shared guard) `which is strongly
+//! protected`; under Tree Borrows,
+//! `this foreign write access would cause the protected tag <B> ... to become
+//! Disabled`. **The two models agree**, which is why the fix is a fix and not
+//! an appeasement of one experimental checker.
+//!
+//! Fix: the guards hold `*mut V` / `*const V` and materialise the reference in
+//! `Deref`/`DerefMut`, where borrowck bounds it to a region in which the guard
+//! cannot be dropped. `core::cell::RefMut` holds a `NonNull<T>` for the same
+//! reason.
+//!
+//! # Teeth
+//!
+//! This file is a **Miri** gate: on native hardware nothing here is observable,
+//! because no real machine invalidates anything on retag. Verified 2026-08-09
+//! by running it against the pre-fix guards — both tests fail under both memory
+//! models, and the `*_scope_exit` control arms, which differ only in NOT moving
+//! the guard, pass. That pairing is what pins the cause to the move rather than
+//! to the tracker: the tracker's grant/refusal counts are the same in all four.
+//!
+//! Keep the explicit `drop(g)`. It is the whole point of the test, and an
+//! "unnecessary" -looking `drop` is the first thing a tidying pass deletes.
+
+use rav1d_disjoint_mut::DisjointMut;
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+const LEN: usize = 32 * 1024;
+/// Contended by every thread, so the race is between a release and an
+/// acquisition of the SAME bytes — which is the only pairing that can pop a
+/// protected tag. Disjoint ranges have disjoint borrow stacks and cannot.
+const SHARED: core::ops::Range<usize> = 4096..4104;
+const THREADS: usize = 7;
+
+/// Miri interprets, so rounds are ~4 orders of magnitude dearer there. The
+/// aliasing violation is not rare — it needs one release to land inside one
+/// concurrent acquisition — so a few hundred rounds is plenty: measured
+/// 2026-08-09 on the pre-fix guards, both tests abort in the first few hundred
+/// acquisitions under both models.
+const ROUNDS: usize = if cfg!(miri) { 400 } else { 200_000 };
+
+/// Liveness floors, as a fraction of the attempts each arm makes. A run that
+/// refused everything, or one whose threads never met, would prove nothing.
+const MIN_GRANTED: usize = THREADS * ROUNDS / 4;
+
+fn contend(mutable_only: bool, move_the_guard: bool) -> (usize, usize) {
+    // One side of every race is a refusal, and refusals are panics.
+    let prev = panic::take_hook();
+    panic::set_hook(Box::new(|_| {}));
+
+    let dm = Arc::new(DisjointMut::new(vec![0u8; LEN]));
+    let granted = Arc::new(AtomicUsize::new(0));
+    let refused = Arc::new(AtomicUsize::new(0));
+
+    let mut hs = Vec::new();
+    for t in 0..THREADS {
+        let dm = Arc::clone(&dm);
+        let granted = Arc::clone(&granted);
+        let refused = Arc::clone(&refused);
+        // In the mixed arm most threads read: shared borrows COEXIST, so a
+        // reader's release overlaps other readers' live borrows, and a writer
+        // arriving next is the foreign retag that pops the protected shared
+        // reference.
+        let reader = !mutable_only && t < 5;
+        hs.push(std::thread::spawn(move || {
+            for _ in 0..ROUNDS {
+                let ok = panic::catch_unwind(AssertUnwindSafe(|| {
+                    if reader {
+                        let g = dm.index(SHARED);
+                        core::hint::black_box(g[0]);
+                        if move_the_guard {
+                            drop(g);
+                        }
+                    } else {
+                        let mut g = dm.index_mut(SHARED);
+                        g[0] = g[0].wrapping_add(1);
+                        if move_the_guard {
+                            drop(g);
+                        }
+                    }
+                }))
+                .is_ok();
+                if ok {
+                    granted.fetch_add(1, Ordering::Relaxed);
+                } else {
+                    refused.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }));
+    }
+    for h in hs {
+        h.join().unwrap();
+    }
+    panic::set_hook(prev);
+    (
+        granted.load(Ordering::Relaxed),
+        refused.load(Ordering::Relaxed),
+    )
+}
+
+fn check(label: &str, mutable_only: bool) {
+    let (moved_ok, moved_refused) = contend(mutable_only, true);
+    // The control arm: identical work, guard destroyed by scope exit instead of
+    // by a move. If this one ever fails, the cause is NOT the move and the
+    // diagnosis above is wrong.
+    let (scoped_ok, scoped_refused) = contend(mutable_only, false);
+
+    assert!(
+        moved_ok > MIN_GRANTED && scoped_ok > MIN_GRANTED,
+        "{label}: the contended range was granted too rarely to have raced \
+         (moved {moved_ok}, scoped {scoped_ok}, floor {MIN_GRANTED})"
+    );
+    assert!(
+        moved_refused > 0 && scoped_refused > 0,
+        "{label}: not one acquisition was refused, so the {THREADS} threads \
+         never actually contended (moved {moved_refused}, scoped \
+         {scoped_refused})"
+    );
+}
+
+#[test]
+fn moving_a_mut_guard_into_drop_is_not_ub() {
+    check("mut", true);
+}
+
+#[test]
+fn moving_a_shared_guard_into_drop_is_not_ub() {
+    check("mixed", false);
+}

--- a/crates/rav1d-disjoint-mut/tests/narrow_release.rs
+++ b/crates/rav1d-disjoint-mut/tests/narrow_release.rs
@@ -31,7 +31,19 @@
 //! still gates the same direction on the new shape; verified 2026-08-08 by
 //! widening `Shard::live_mask`'s `allocated <= 1` fast path to `<= 2`, which
 //! makes the mask a SUBSET of the live set and drops live neighbours: this
-//! test, and only this test, FAILS.
+//! test, and only this test, FAILS. That mutation was RE-VERIFIED 2026-08-09
+//! on the current shape: `witnesses` = 1, in 2.52 s, at private_ok 4_200_000 /
+//! shared_ok 1_200_246 / refused 199_754. The paragraph above is a live
+//! record, not a stale one.
+//!
+//! # It is also the crate's aliasing gate, and that is why it runs under Miri
+//!
+//! The tracker cannot tell you whether the REFERENCES it hands out obey Rust's
+//! aliasing model — only Miri can, and this is the only test in the suite that
+//! drives a release and an overlapping acquisition of the same bytes hard
+//! enough for Miri to schedule one inside the other. It is what found the
+//! guards' by-value-move defect (2026-08-09, `tests/guard_move_release.rs`
+//! now gates that specific shape). Do not drop it from the Miri leg.
 //!
 //! # How
 //!
@@ -62,7 +74,42 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 const LEN: usize = 32 * 1024;
 
 const THREADS: usize = 7;
-const ROUNDS: usize = 200_000;
+
+/// Native rounds. Under Miri, four orders of magnitude fewer — see below.
+const ROUNDS: usize = if cfg!(miri) { 400 } else { 200_000 };
+
+/// Liveness floors.
+///
+/// The native pair (10_000 / 1_000) is unchanged. The Miri pair is NOT a
+/// relaxation of it: at 400 rounds the arms attempt 8_400 private and 2_800
+/// shared acquisitions, so 4_000 / 700 are floors at ~48% and ~25% of
+/// attempts, where the native floors sit at ~0.24% and ~0.07%. The Miri run is
+/// held to a proportionally TIGHTER standard, not a looser one. Measured
+/// 2026-08-09, M4 Pro, `--test narrow_release` at 400 Miri rounds:
+///
+/// ```text
+///   Stacked Borrows   private_ok 8400   shared_ok 1846   refused 954
+///   Tree Borrows      private_ok 8400   shared_ok 1862   refused 938
+/// ```
+///
+/// Why the round count moves at all: Miri interprets. Two-point fit of this
+/// test's own wall time under Stacked Borrows, `total = a + b * rounds`, from
+/// 23.12 s at 100 rounds and 92.19 s at 400 (same host, same day):
+/// b = 0.230 s/round, a = 0.10 s. Extended to 200_000 that is **~12.8 hours per
+/// memory model** — the Miri leg could never have finished it, and never did:
+/// run 31292996318 reached this file only because it ABORTED on UB.
+///
+/// What the Miri leg is for is the ALIASING MODEL, and that does not need a
+/// long race. **What the shorter run costs, stated honestly:** re-run against
+/// the pre-fix guards on 2026-08-09, this file at 400 rounds still aborts under
+/// Stacked Borrows on the default seed (same tag, `<129070>`, as CI run
+/// 31292996318) — but under Tree Borrows it did NOT reproduce at either of the
+/// two seeds tried (0 and 1). Tree-Borrows coverage of that defect rests on
+/// `tests/guard_move_release.rs`, which contends the same range harder and
+/// aborts under BOTH models on the default seed. The native run here keeps the
+/// full 200_000, which is what gates the tracker's own race behaviour.
+const MIN_PRIVATE_OK: usize = if cfg!(miri) { 4_000 } else { 10_000 };
+const MIN_SHARED_OK: usize = if cfg!(miri) { 700 } else { 1_000 };
 
 /// The contended interval. Every thread tries to take exactly this range
 /// mutably, so any two simultaneous grants are a provable overlap.
@@ -161,12 +208,12 @@ fn a_lock_free_release_never_retires_a_live_neighbour() {
     // Liveness. A tracker that refused everything, or one whose threads never
     // met, would report zero witnesses for the wrong reason.
     assert!(
-        private_ok.load(Ordering::Relaxed) > 10_000,
+        private_ok.load(Ordering::Relaxed) > MIN_PRIVATE_OK,
         "private churn barely ran ({}); the release path was not exercised",
         private_ok.load(Ordering::Relaxed)
     );
     assert!(
-        shared_ok.load(Ordering::Relaxed) > 1_000,
+        shared_ok.load(Ordering::Relaxed) > MIN_SHARED_OK,
         "the shared range was granted almost never ({}); the race window was \
          never exercised",
         shared_ok.load(Ordering::Relaxed)

--- a/crates/rav1d-disjoint-mut/tests/narrow_release.rs
+++ b/crates/rav1d-disjoint-mut/tests/narrow_release.rs
@@ -31,10 +31,12 @@
 //! still gates the same direction on the new shape; verified 2026-08-08 by
 //! widening `Shard::live_mask`'s `allocated <= 1` fast path to `<= 2`, which
 //! makes the mask a SUBSET of the live set and drops live neighbours: this
-//! test, and only this test, FAILS. That mutation was RE-VERIFIED 2026-08-09
-//! on the current shape: `witnesses` = 1, in 2.52 s, at private_ok 4_200_000 /
-//! shared_ok 1_200_246 / refused 199_754. The paragraph above is a live
-//! record, not a stale one.
+//! test, and only this test, FAILS. RE-VERIFIED in full on 2026-08-09, both
+//! halves: with `<= 2` planted, this test fails (`witnesses` = 1, in 2.52 s, at
+//! private_ok 4_200_000 / shared_ok 1_200_246 / refused 199_754) and
+//! `--no-fail-fast` over the rest of the suite — 26 lib + 25 `soundness` + 5
+//! `shard_liveness` + `wide_exclusion` + 2 `guard_move_release` — is GREEN.
+//! The paragraph above is a live record, not a stale one.
 //!
 //! # It is also the crate's aliasing gate, and that is why it runs under Miri
 //!

--- a/crates/rav1d-disjoint-mut/tests/shard_liveness.rs
+++ b/crates/rav1d-disjoint-mut/tests/shard_liveness.rs
@@ -22,7 +22,40 @@ const LEN: usize = 24 * 1024;
 
 /// Offsets chosen to sit on, just below, and just above every block size the
 /// tracker might be compiled with, plus a few arbitrary ones.
+///
+/// # Under Miri this list is cut to six, and that is not optional
+///
+/// The pair loop is quadratic in this list and constructs a FRESH
+/// `DisjointMut::new(vec![0u8; 24 KiB])` per pair (it has to — see the comment
+/// at the allocation). Natively that is 331_776 pairs in 0.85 s. Under Miri
+/// every one of those 24_576 zero bytes is an emulated write. Measured on an
+/// M4 Pro, 2026-08-09:
+///
+/// ```text
+///   start list          pairs     Miri wall     per pair
+///   [0, 1, 3]           2_916      117.8 s       40 ms
+///   the six below      11_236      991.2 s       80 ms   (whole binary, 5 tests)
+///   full (native)     331_776        0.85 s       —
+/// ```
+///
+/// The rate depends on the mix — the six below include offsets whose 20_000-byte
+/// `LENS` take the WIDE path and lock every shard — so the full list is
+/// somewhere between **3.7 and 7.4 hours PER MEMORY MODEL for this one test**.
+/// Either end of that is past what a CI job can do.
+///
+/// That is why the `disjoint-mut CI` Miri leg has never been observed green:
+/// before 2026-08-09 it aborted earlier, on the guard-move UB (#477), and would
+/// have parked here if it had not. The native run is UNCHANGED and stays
+/// exhaustive; the Miri run keeps one representative of each interesting class
+/// — buffer start, a block-boundary triple, a large power of two, and an offset
+/// far enough in that the long `LENS` clip — which is what the aliasing model
+/// needs to see. Coverage of the tracker's *predicate* is the native run's job,
+/// and `exhaustive_pairs_match_the_interval_predicate` asserts a scaled floor on
+/// both so neither can silently degenerate.
 fn starts() -> Vec<usize> {
+    if cfg!(miri) {
+        return vec![0, 63, 64, 65, 4096, 20000];
+    }
     let mut v = vec![0usize, 1, 3, 7, 63, 64, 65];
     for base in [256usize, 512, 1024, 2048, 4096, 8192, 16384] {
         for d in [-1isize, 0, 1] {
@@ -135,8 +168,14 @@ fn exhaustive_pairs_match_the_interval_predicate() {
         wrong.len(),
         wrong.join("\n")
     );
-    // Guard against the test silently degenerating to nothing.
-    assert!(checked > 50_000, "only {checked} pairs exercised");
+    // Guard against the test silently degenerating to nothing. The Miri floor
+    // is proportional to its own (deliberately smaller) start list — see
+    // `starts()` — not a relaxation of the native one, which is untouched.
+    let floor = if cfg!(miri) { 2_000 } else { 50_000 };
+    assert!(
+        checked > floor,
+        "only {checked} pairs exercised (floor {floor})"
+    );
     eprintln!("checked {checked} borrow pairs");
 }
 

--- a/crates/rav1d-disjoint-mut/tests/wide_exclusion.rs
+++ b/crates/rav1d-disjoint-mut/tests/wide_exclusion.rs
@@ -55,7 +55,21 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 const LEN: usize = 8 * 1024 * 1024;
 
 const NARROW_THREADS: usize = 6;
-const ROUNDS: usize = 60_000;
+/// Native rounds. Under Miri this is 300, for the reason spelled out on
+/// `shard_liveness::starts()`: every round here takes a WHOLE-BUFFER borrow of
+/// an 8 MiB instance, which promotes to the wide path and locks all 128 shards,
+/// while six narrow threads contend — and Miri emulates every one of those
+/// atomics. Measured 2026-08-09 on an M4 Pro: **300 rounds takes 181.7 s**, and
+/// both liveness floors are met at that count; 60_000 rounds was still running
+/// after 10 minutes when it was killed, on both memory models. The native run
+/// is unchanged at 60_000 (0.05 s), and the `wide-path-gate` CI job — the one
+/// that proves this file is non-vacuous, via `--features __probe_wide` — is
+/// native, so the anti-vacuity evidence does not depend on the Miri count.
+const ROUNDS: usize = if cfg!(miri) { 300 } else { 60_000 };
+
+/// Narrow-side liveness floor, scaled with `ROUNDS`. The narrow threads spin
+/// until the wide loop finishes, so their count tracks the round count.
+const MIN_NARROW_OK: usize = if cfg!(miri) { 100 } else { 1000 };
 
 #[test]
 fn a_wide_borrow_excludes_every_narrow_shard() {
@@ -149,7 +163,7 @@ fn a_wide_borrow_excludes_every_narrow_shard() {
         wide_ok.load(Ordering::Relaxed)
     );
     assert!(
-        narrow_ok.load(Ordering::Relaxed) > 1000,
+        narrow_ok.load(Ordering::Relaxed) > MIN_NARROW_OK,
         "the narrow registrants were refused almost every round ({}); the race \
          window was never exercised",
         narrow_ok.load(Ordering::Relaxed)

--- a/crates/rav1d-disjoint-mut/tests/wide_exclusion.rs
+++ b/crates/rav1d-disjoint-mut/tests/wide_exclusion.rs
@@ -54,14 +54,26 @@ use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 /// past `MAX_BLOCKS_SCAN` blocks, i.e. genuinely wide.
 const LEN: usize = 8 * 1024 * 1024;
 
-const NARROW_THREADS: usize = 6;
+/// Narrow contenders. Two under Miri, and that is a SCHEDULING fix, not a
+/// weakening of the gate — the assertions are untouched.
+///
+/// At six, Miri's scheduler starves the wide registrant: under Tree Borrows it
+/// was granted 3 rounds out of 300 and the gate correctly refused to report
+/// green ("the wide registrant was refused almost every round (3)"). That is the
+/// anti-vacuity assertion doing its job, so the fix is to stop starving the wide
+/// side rather than to lower the floor. Two contenders still put a narrow
+/// registrant against a provably-held wide borrow, which is the whole predicate.
+/// Native keeps six.
+const NARROW_THREADS: usize = if cfg!(miri) { 2 } else { 6 };
 /// Native rounds. Under Miri this is 300, for the reason spelled out on
 /// `shard_liveness::starts()`: every round here takes a WHOLE-BUFFER borrow of
 /// an 8 MiB instance, which promotes to the wide path and locks all 128 shards,
 /// while six narrow threads contend — and Miri emulates every one of those
-/// atomics. Measured 2026-08-09 on an M4 Pro: **300 rounds takes 181.7 s**, and
-/// both liveness floors are met at that count; 60_000 rounds was still running
-/// after 10 minutes when it was killed, on both memory models. The native run
+/// atomics. Measured 2026-08-09 on an M4 Pro: **300 rounds takes 91.9 s under
+/// Stacked Borrows and 91.5 s under Tree Borrows** (with the reduced
+/// `NARROW_THREADS` below; 181.7 s at six), and both liveness floors are met on
+/// both models; 60_000 rounds was still running after 10 minutes when it was
+/// killed, on both models. The native run
 /// is unchanged at 60_000 (0.05 s), and the `wide-path-gate` CI job — the one
 /// that proves this file is non-vacuous, via `--features __probe_wide` — is
 /// native, so the anti-vacuity evidence does not depend on the Miri count.

--- a/examples/md5_inventory.rs
+++ b/examples/md5_inventory.rs
@@ -180,11 +180,7 @@ fn hash_frame(frame: &Frame, ctx: &mut md5::Context) {
     }
 }
 
-fn decode_md5(
-    ivf_path: &Path,
-    apply_grain: bool,
-    threads: u32,
-) -> Result<(String, usize), String> {
+fn decode_md5(ivf_path: &Path, apply_grain: bool, threads: u32) -> Result<(String, usize), String> {
     let file = std::fs::File::open(ivf_path).map_err(|e| format!("open: {e}"))?;
     let mut reader = std::io::BufReader::new(file);
     let frames = ivf_parser::parse_all_frames(&mut reader).map_err(|e| format!("ivf: {e}"))?;

--- a/examples/md5_inventory.rs
+++ b/examples/md5_inventory.rs
@@ -18,6 +18,10 @@
 //! Optional args:
 //!   --group <substr>   only run meson groups whose relative path contains this
 //!   --name <substr>    only run vectors whose name contains this
+//!   --threads <n>      decoder thread count (default 1). Run the gate at 1
+//!                      AND at 8: at 1 the tile workers never start, so a
+//!                      single-threaded-only gate cannot see a borrow-tracker
+//!                      or threading regression at all.
 
 use rav1d_safe::src::managed::{Decoder, Frame, Planes, Settings};
 use std::io::Write;
@@ -176,13 +180,18 @@ fn hash_frame(frame: &Frame, ctx: &mut md5::Context) {
     }
 }
 
-fn decode_md5(ivf_path: &Path, apply_grain: bool) -> Result<(String, usize), String> {
+fn decode_md5(
+    ivf_path: &Path,
+    apply_grain: bool,
+    threads: u32,
+) -> Result<(String, usize), String> {
     let file = std::fs::File::open(ivf_path).map_err(|e| format!("open: {e}"))?;
     let mut reader = std::io::BufReader::new(file);
     let frames = ivf_parser::parse_all_frames(&mut reader).map_err(|e| format!("ivf: {e}"))?;
 
     let mut settings = Settings::default();
     settings.apply_grain = apply_grain;
+    settings.threads = threads;
     let mut decoder = Decoder::with_settings(settings).map_err(|e| format!("decoder: {e}"))?;
     let mut ctx = md5::Context::new();
     let mut n = 0usize;
@@ -214,6 +223,11 @@ fn main() {
     let mut group_filter: Option<String> = None;
     let mut name_filter: Option<String> = None;
     let mut activity = false;
+    // The corpus gate defaulted to one thread, which made it structurally
+    // blind to anything the tile workers do differently — including every
+    // change to the borrow tracker, whose whole reason to exist is
+    // multi-threaded decode. Run it at 1 AND at 8 and set-diff the two.
+    let mut threads = 1u32;
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
@@ -231,6 +245,13 @@ fn main() {
             // reports "never called" and "free" as the same 0.0 ms. Needs
             // `--features __ablate`; without it every count is 0 and the
             // assert below refuses to emit a misleading all-zero column.
+            "--threads" => {
+                threads = args
+                    .get(i + 1)
+                    .and_then(|v| v.parse().ok())
+                    .expect("--threads needs a number");
+                i += 2;
+            }
             "--activity" => {
                 activity = true;
                 i += 1;
@@ -305,13 +326,13 @@ fn main() {
             }
             // Marker so a `__simd_test_log` build's per-call `*_MISMATCH` lines
             // (which go to stderr) can be attributed to the vector that
-            // produced them. Sound because `Settings::threads` defaults to 1
-            // and `decode_md5` joins before returning, so no worker line can
-            // straddle two vectors.
+            // produced them. Sound at `--threads 1`, and still sound above
+            // it because `decode_md5` joins before returning, so no worker
+            // line can straddle two vectors (they may interleave WITHIN one).
             eprintln!("VECTOR\t{group_key}\t{}", v.name);
             rav1d_safe::src::ablate::activity_reset();
             let t0 = Instant::now();
-            let res = decode_md5(&v.ivf_path, grain);
+            let res = decode_md5(&v.ivf_path, grain, threads);
             let ms = t0.elapsed().as_millis();
             let act = if activity {
                 let counts = rav1d_safe::src::ablate::activity_snapshot();
@@ -352,5 +373,5 @@ fn main() {
         eprintln!("done {group_key}");
     }
 
-    eprintln!("TOTAL pass={pass} mismatch={fail} error={err} skip={skip}");
+    eprintln!("TOTAL threads={threads} pass={pass} mismatch={fail} error={err} skip={skip}");
 }


### PR DESCRIPTION
Closes #477.

**CI status.** On `eeca861` the `disjoint-mut CI` run was green on all 13 jobs
**including both Miri legs** — the first time either has been observed to pass
(run 31332576512). The main `CI` workflow's `Format` job caught an unformatted
`examples/md5_inventory.rs` on that commit, fixed in `2aa4222`.

## Root cause — it is the library, not the test

`tests/narrow_release.rs` was right and `DisjointMut`'s release path was wrong.

Both guards carried the borrowed region as a **reference** (`slice: &'a mut V`,
`slice: &'a V`). A guard is a value, so safe code moves it — `drop(g)` above all.
Rust's aliasing model gives every reference passed **by value into a call** a
*protector*: for the whole of that call the reference must stay valid and nothing
may invalidate it. The guard's `Drop` runs inside that very call and **retires the
tracker record**, and retiring is exactly what authorises *another thread* to take
the region and retag those bytes. The protected reference is invalidated
mid-call.

Reachable from safe code, on the release path the whole crate exists to provide.

### The reduction that settles test-vs-library

Three arms, identical in every respect except **how the guard is destroyed**;
7 threads all contending one 8-byte range (`crates/rav1d-disjoint-mut`, Miri,
M4 Pro):

| arm | SB | TB | tracker grants / refusals |
|---|---|---|---|
| `drop(g)` — by-value move | **UB** | **UB** (seeds 1,2,3; seed 0 lucky) | 2239 / 561 |
| scope exit — no move | clean | clean | 2228 / 572 |
| `eat(g)` — any by-value move | **UB** | **UB** (seed 0) | 2226 / 574 |

The tracker grants and refuses identically in all three, so the tracker is not
the variable — the move is. `drop(g)` is ordinary safe code, so this is a library
defect, not a test-construction artifact.

The shared guard has the same defect (`[SharedReadOnly for <B>] which is strongly
protected` under SB, a forbidden foreign write under TB), found by the same
reduction with readers and writers on one range.

### Both memory models agree

- **Stacked Borrows:** `not granting access to tag <129070> because that would
  remove [Unique for <5656840>] which is strongly protected` — the same tag as CI
  run 31292996318.
- **Tree Borrows:** `this foreign write access would cause the protected tag
  <B> (currently Reserved (conflicted)) to become Disabled`.

A Stacked-Borrows-only report would be a weaker signal. This is not that.

## Fix

Both guards hold `NonNull<V>` and materialise the reference in `Deref`/`DerefMut`,
where borrowck bounds it to a region in which the guard cannot be dropped.
`index_mut`/`index` no longer create a reference at all.

This is precisely why `core::cell::RefMut` holds a `NonNull<T>`; its comment reads
*"we use a pointer instead of `&'b mut T` to avoid `noalias` violations, because a
`RefMut` argument doesn't hold exclusivity for its whole scope, only until it
drops."* `DisjointMut`'s cross-thread release makes it sharper: for us another
thread is genuinely retagging the bytes.

**Auto-traits.** A raw-pointer field is `!Send`/`!Sync` and `PhantomData` cannot
argue it back, so four `unsafe impl`s restore what the compiler derived from the
reference fields. Verified, not asserted: the same positive bound probes compile
on both revisions and the same three negative probes (`V: !Send`, `T: !Sync`,
`&V: Send` needing `V: Sync`) fail to compile on both. The bounds are neither
wider nor narrower.

**`unsafe` accounting, stated plainly rather than claimed away.** In
`crates/rav1d-disjoint-mut/src/` the counts move: `unsafe {}` blocks 47 -> 54,
`unsafe impl` 16 -> 20, `unsafe fn` definitions 31 -> 31, bare `unsafe` tokens
102 -> 113. The seven new blocks are not new unchecked operations — they are the
same pointer derefs, moved out of `index_mut`/`index` (which no longer deref at
all) into `Deref`/`DerefMut` and the four zerocopy cast sites. That relocation
IS the fix. The four new `unsafe impl`s add zero operations; they re-state
auto-traits the compiler used to derive, and dropping them would be a silent
semver break. The parent crate is untouched: its `unsafe` token count is
identical (2352 -> 2352) and `forbid(unsafe_code)` is proved active by planting
a block and watching the build fail.

## Gates

- **`tests/guard_move_release.rs` (new).** Fails under **both** models on the
  default seed against the pre-fix guards; passes on both after. Carries
  scope-exit control arms, so a future failure that is *not* about the move is
  distinguishable. Miri 110 s/model, native 0.9 s.
- **`narrow_release` mutation re-verified.** Its header claims widening
  `Shard::live_mask`'s `allocated <= 1` to `<= 2` makes this test, and only this
  test, fail. Both halves re-run on the current shape: with `<= 2` planted this
  test fails (`witnesses` = 1, 2.52 s) and `--no-fail-fast` over the rest of the
  suite is green. `guard_move_release` passing under it is the useful part — the
  two gates are orthogonal, one for the tracker and one for the aliasing model.
  The header is a live record, not a stale one; I extended it rather than
  replacing it.
- **Corpus 766/766**, set-diffed **by name with the actual MD5 in the value**,
  against both `main` and `benchmarks/aarch64_md5_fixes_2026-08-07_final.tsv.zst`:
  768 rows, zero only-in-either, zero differing values. At `--threads 8`,
  755 non-film-grain rows match `main` exactly — and **HEAD t=1 vs HEAD t=8 differ
  in zero MD5s**, which is the property a borrow-tracker change could break and a
  single-threaded gate could never see.
- **Standing hazards.** `active()` cut to one shard → `wide_exclusion` fails
  (418 violations) under `--features __probe_wide`. The 4af62ae TOCTOU deletion →
  see the honest note below. Both restored from byte-level snapshots, `shasum -c`
  OK and `git diff` empty against `main`.
- **`forbid(unsafe_code)` proved actively** in the parent crate: an `unsafe` block
  planted in `src/lib.rs` fails the default-feature build with
  `error: usage of an 'unsafe' block`. Restored, `git diff` empty.
- `cargo fmt --check`, `cargo clippy -D warnings` (default and
  `--no-default-features`), full native suite green in both feature configs.

## Performance — the first cut cost 1.2% and this one does not

`scripts/perf/verify_gap.sh`, rotating arm order per cell, two-point wall fit at
2 and 20 frames, strict idle gate (**foreign>25%-CPU count 0 in all 27 committed
cells, 0 discarded**), no `nice` on a timed run, no `-C target-cpu=native`. Apple
M4 Pro.

The first cut used a bare `*mut V`. That measured **+1.2% at v4k_8tile t=1 with
every paired ratio above 1.0** — small, but 7/7 in sign and the band excluded
1.000, so not noise. A reference field carries `nonnull` (and the niche) into
every load of the guard; a raw pointer drops both.

Three-arm confirm (n=9, `base` / `head`=bare pointer / `head2`=`NonNull` +
`#[inline(always)]` derefs):

| vec | t | base ms/frame | head/base | head2/base |
|---|---|---|---|---|
| v4k_8tile | 1 | 318.44 | 1.0114 [1.0009, 1.0337] | **1.0005** [0.9331, 1.0119] |
| v4k_8tile | 8 | 67.44 | 1.0034 [0.9712, 1.0404] | 0.9926 [0.9715, 1.0358] |
| v4k_8tile_10b | 8 | 72.89 | 0.9838 [0.9754, 1.0116] | 0.9933 [0.9808, 1.0108] |

It reproduces the regression on `head` and shows `head2` recovering it. Both t=8
cells are null for both arms in both runs. `head2` is what ships. `NonNull` and
the inline attribute were changed together and are reported together — **no
per-knob attribution is claimed.**

Full record, including run A (n=7) which found it: `benchmarks/miri_guard_move_2026-08-09.meta`.

## Also in this PR

**The Miri workflow leg could not report which model failed.**
`name: Miri (${{ matrix.model }})` renders `Miri (Object)` for *both* legs
(`model` is an object). In run 31292996318 one leg was `failure` and the other
`cancelled` and there was no way to tell which model found the UB. Now
`matrix.model.name`, plus `fail-fast: false`.

**`--no-fail-fast` on the Miri leg.** Miri aborts the process on first UB and
cargo stops at the first failing *target*, so the abort in `narrow_release` meant
`soundness`, `shard_liveness`, `wide_exclusion`, `aligned_miri` and
`pic_buf_overflow` never ran at all — and their silence read as health.

**`narrow_release` gets a `cfg(miri)` round count (400 vs 200_000).** Not a
relaxation, and measured rather than guessed: a two-point fit of its own Miri wall
time (23.12 s at 100 rounds, 92.19 s at 400) gives 0.230 s/round, so 200_000
rounds is **~12.8 hours per memory model**. The Miri leg could never have finished
it and never has. The **native** run keeps the full 200_000. The Miri liveness
floors are proportionally *tighter* than the native ones (48% / 25% of attempts
vs 0.24% / 0.07%).

**`md5_inventory --threads N`.** The corpus gate defaulted to one thread, which
made it structurally blind to anything the tile workers do — including every
change to the borrow tracker.

## The whole Miri suite, per binary, per model

Run each binary SEPARATELY, because Miri aborts on first UB and cargo stops at
the first failing target.

| binary | Stacked Borrows | Tree Borrows |
|---|---|---|
| `aligned_miri` | ok, 0 tests, 0.04 s | ok, 0.04 s |
| `pic_buf_overflow` | ok, 0 tests, 0.03 s | ok, 0.03 s |
| `soundness` | ok, 25 tests, 9.59 s | ok, 25 tests, 9.69 s |
| `wide_exclusion` | ok, 1 test, 181.66 s | **FAILED**, 180.44 s (*) |
| `narrow_release` | ok, 1 test, 92.76 s | ok, 1 test, 92.95 s |
| `guard_move_release` | ok, 2 tests, 110.99 s | ok, 2 tests, 112.19 s |
| `shard_liveness` | ok, 5 tests, 992.69 s | ok, 5 tests, 993.11 s |
| `lib` | ok, 26 tests, 1488.78 s | **TIMED OUT** (**) |

(*) **Not UB, and not the shipped configuration.** That leg ran the six-contender
`wide_exclusion`; its anti-vacuity assertion fired because Miri's scheduler
starves the wide registrant (3 grants in 300 rounds). Fixed by cutting Miri to
two narrow contenders — assertions untouched — and re-run on both models
afterwards: **ok in 91.88 s (SB) and 91.45 s (TB)**. That pair is the shipped
number.

(**) rc=124 — the harness's 7_200 s cap, with 22 of 26 done, inside
`tracker_shard::tests::threaded_disjoint_is_clean`. **Not a failure, and not UB.**
Its Stacked-Borrows twin did the same 26 tests in 1488.78 s (which independently
matches the 1489 s CI reported for the lib on `main`), so Tree Borrows is >5×
slower on exactly two loops: `threaded_churn_leaks_no_slots` (8 threads ×
50_000 add/remove pairs, all on ONE shard) and `threaded_disjoint_is_clean`
(8 × 20_000). **Fourth and last blocker, fixed the same way** — `cfg(miri)`
counts of 1_500 / 1_000, native untouched, both inside `#[cfg(test)] mod tests`
so no library code moves:

| | before | after |
|---|---|---|
| lib, Stacked Borrows | 1488.78 s | **66.77 s**, 26/26 |
| lib, Tree Borrows | >7200 s, timed out at 22/26 | **66.72 s**, 26/26 |

**No UB anywhere on the fixed tree.** Every failure in that table is a liveness
assertion or a timeout, and both are fixed above. **Total ~23 min per model at
the shipped configuration, on either model, against "cannot finish" before.**

## Honest gaps

1. **The 4af62ae TOCTOU plant only fails `wide_exclusion` on the CONTENDED path.**
   Deleting the in-lock `state` re-read from `add_contended` fails 5/5 runs
   (929–1674 violations). Deleting it from `add`'s `try_lock` fast path **alone**
   passed 8/8. Structurally plausible — the wide registrant holds every shard lock
   while it publishes, so a narrow registrant in that window fails `try_lock` by
   construction and lands in `add_contended` — but the fast-path half of that
   hazard is **not** covered by the gate on this box.

2. **At 400 Miri rounds, `narrow_release` keeps its teeth under Stacked Borrows
   only.** Against the pre-fix guards it aborts under SB on the default seed but
   did **not** reproduce under Tree Borrows at seed 0 or seed 1. Tree-Borrows
   coverage of this defect therefore rests on `guard_move_release`. Recorded in
   the test's own header, not just here.

3. **The guard UB was not the only thing stopping the Miri leg — fixed here too.**
   Doing item 7 of #477 (enumerate the whole suite) surfaced that
   `shard_liveness::exhaustive_pairs_match_the_interval_predicate` cannot run
   under Miri at all. It builds a FRESH `DisjointMut::new(vec![0u8; 24 KiB])` per
   pair (it must — a poisoned tracker would mask later results), so each of its
   331_776 pairs is 24_576 emulated zero-writes plus a 128-shard tracker:

   | start list | pairs | Miri wall | per pair |
   |---|---|---|---|
   | `[0, 1, 3]` | 2_916 | 117.8 s | 40 ms |
   | the six now shipped | 11_236 | 991.2 s | 80 ms (whole binary, 5 tests) |
   | full (native) | 331_776 | 0.85 s | — |

   Full list projects to **3.7–7.4 h per memory model for this one test** (the
   spread is the mix; the shipped six include offsets whose 20_000-byte `LENS`
   take the wide path and lock every shard). I let it run 53 minutes under
   Stacked Borrows without finishing before measuring why. Same treatment as
   `narrow_release`: native untouched and still exhaustive (331_776 pairs,
   0.85 s, re-verified), Miri gets six representative starts, anti-vacuity floor
   scaled 50_000/2_000.

   A fourth blocker turned up in the lib tests and is Tree-Borrows-only — see
   the `lib` row of the table above. **So the `disjoint-mut CI` Miri leg has
   never been green and could not have been**, whatever the guards did; four
   separate things had to change before it could even finish.

4. **Pre-existing, NOT fixed here, needs its own issue: film grain overlaps the
   whole plane at `--threads > 1`.** `md5_inventory --threads 8` aborts at the
   first film-grain vector on `main` and on this branch identically (same 13
   vectors lost, rc=101):
   ```
   overlapping DisjointMut:
    current: &mut _[0..147456] on ThreadId(6) at src/safe_simd/filmgrain_arm.rs:1550:53
   existing: &mut _[0..147456]                at src/safe_simd/filmgrain_arm.rs:1550:53
   ```
   `fgy_32x32xn`'s NEON path calls `full_guard_mut::<BD>()` — a **whole-plane**
   mutable guard — per row worker. The rows written are disjoint; the borrows
   registered are not, and at the Rust level N concurrent `&mut [u8]` over the
   same plane is UB regardless. The threads=8 corpus comparison in this PR is
   therefore over the 755 rows that run before that abort; they match `main`
   row-for-row.

5. **Not audited:** whether any *other* zen crate holds a `DisjointMut` guard in a
   struct that is moved by value. The fix makes that harmless, so this is a
   completeness note, not a risk.
