### PR TITLE
perf(lf-band): LfBlock::fill attributed 69/31, and the band that removes 29.6% of all registrations is REFUSED (default off)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,11 @@ probe-sites = ["rav1d-disjoint-mut/__probe_sites"]
 # Absent from `default` and from every published feature. See
 # `src/loopfilter.rs::lf_hull_reads` and docs/MUT_RECON_KERNELS.md section 10.
 __probe_lf_hull = []
+# Measurement-only: counts `LfBlock::fill`'s registrations split by direction
+# (H = vertical edges, `filter_plane_cols_*`; V = horizontal edges,
+# `filter_plane_rows_*`) and by run length, so the site's population can be
+# attributed before anything is built against it. Counts only, never a policy.
+__probe_lf_hist = []
 probe-tinynop = ["rav1d-disjoint-mut/__probe_tinynop"]
 probe-addnop = ["rav1d-disjoint-mut/__probe_addnop"]
 probe-noscan = ["rav1d-disjoint-mut/__probe_noscan"]

--- a/docs/MUT_RECON_KERNELS.md
+++ b/docs/MUT_RECON_KERNELS.md
@@ -1090,3 +1090,114 @@ Net **-2,459,800 registrations/frame, -21.6% of the whole decoder's
 population**, bought at an extent of 142 contiguous bytes per guard. That is
 the opposite trade from §11c's hull, which removed 3.46 M by paying 50-60 KB
 of strided extent and measured **2.65x SLOWER**.
+
+## 18. The band is REFUTED under concurrent filtering — and the first run passed
+
+§17's registration table is real and the band is nevertheless **not
+shippable**. It ships **default OFF** (`RAV1D_LF_BAND=1` to arm), in the shape
+`__probe_lf_hull` already uses for the strided-hull negative.
+
+### What went wrong
+
+**The loop filter's read set is 2-D SPARSE, and every per-row band is
+contiguous.** A band reserves, for each of its rows, one span covering the
+whole superblock; the pass actually reads only the `+-reach` tap windows
+around the edges that filter, and a row in which nothing filters is not read
+at all. The difference is columns and rows that are reserved but never read —
+and under concurrent filtering another worker is legitimately writing them:
+
+```text
+current:  &     _[163840..163968]   <- the band's 128-px row copy-in
+existing: &mut  _[163944..163952]   <- a concurrent 8-px write inside it
+```
+
+That is the SAME defect class as §11c's hull, transposed. The hull reserved
+the gaps BETWEEN rows; this reserves the gaps BETWEEN edges. §11c's version
+was merely slow because its extent hit the wide path; this one is a false
+positive, i.e. a decode failure.
+
+### The numbers, and the sample that lied
+
+`examples/md5_inventory --threads 8`, group `8-bit/data` (358 vectors), same
+box, same load, repeated:
+
+| arm | pass | error |
+|---|---|---|
+| base commit `0f6bf10`, its own binary | 358 / 358 / 358 | **0 / 0 / 0** |
+| band off (this binary) | 358 / 358 | 0 / 0 |
+| **column band only** | 357 / 356 / 358 | **1 / 2 / 0** |
+| **column + row band** | 294 | **64** |
+| default build (band off), after the fix | 358 x4 | **0 x4** |
+
+**The column-only band's first full `--threads 8` corpus run passed 753/755
+`SETDIFF: CLEAN`.** One sample. It was committed on that basis, and the
+failure only appeared when the row band widened the same defect enough to fire
+reliably. "766 vectors passed" is evidence, not a proof — and a rare
+false positive is a decode failure, not a wrong pixel, so it cannot be
+detected by an md5 diff at all, only by an error count.
+
+### `tile_threading_active()` is the WRONG gate, measured
+
+The obvious rescue is the latch that already lets `fill_hull`, `block_mut` and
+`compact_read` widen a reservation. It does not work, because it gates
+concurrent **tile** workers and the loop filter's concurrency is between
+**sbrow filter tasks** — inserted for `sby+1` before the selected task for
+`sby` even runs (`src/thread_task.rs:1030-1043`) — which exist whenever
+`n_tc > 1` however many tiles a frame has. Gated that way:
+
+* the `v4k_8tile` t=8 census is byte-identical to `main` (11,401,399), so the
+  band provably never armed on that vector, and
+* `8-bit/data` at t=8 **still produced 8 errors in one run of two.**
+
+A gate that is right for this site would have to mean "no other thread can be
+filtering this picture", which the decoder does not currently expose.
+
+### What the default build is
+
+Byte-for-byte `main`'s behaviour, verified rather than assumed:
+
+* census, `--features probe-sites`, `lost=0`: **6,005,602** at t=1 and
+  **11,401,399** at t=8 — both exactly §11a's numbers;
+* corpus set-diffed BY NAME with the md5 as the value, against
+  `benchmarks/aarch64_md5_fixes_2026-08-07_final.tsv.zst`: `--threads 1`
+  **766 PASS / 768 keys / 0 differing, SETDIFF: CLEAN**; `--threads 8` with
+  both film-grain groups dropped from BOTH sides (#479) **753 PASS / 755 keys
+  / 0 differing, SETDIFF: CLEAN**;
+* the write population is untouched in every arm: 17,852 per frame, split
+  17,327 + 525 between `close` and `close_band` when armed.
+
+### The one number the armed arm is still good for
+
+Paired user CPU, `v4k_8tile` 8bpc t=8, 20 frames, one binary, arms interleaved
+with rotating order within each round, under `measlock`, n=9 (foreign_max=1,
+so load-tagged):
+
+| | median | band | faster |
+|---|---|---|---|
+| band / band-off | **0.9628** | [0.9523..0.9781] | **9/9** |
+
+**That is a real 3.7% and it is not available**, because the arm that produced
+it is the arm that fails 1-64 vectors per run. It is recorded because it
+prices what a SOUND removal of this population would be worth: it is the
+first direct measurement that removing ~2.4 M of `fill`'s registrations
+without paying extent is worth several percent of CPU, which §11f could only
+bound from above by doubling.
+
+### What the next attempt should and should not do
+
+* **Do not build another contiguous band.** Column-major, row-major, and both
+  together are now all measured. The obstruction is that the read set is
+  sparse in 2-D and the tracker's unit is an interval.
+* **The V pass has a cheap, sound, un-taken win**: §16 measured that lifting
+  `LF_BATCH_MAX` from 4 to 32 divides the V pass's registrations by **1.971**
+  (1,178,490 -> 597,876/frame) with **no extent change beyond a contiguous
+  in-row span that the fused groups genuinely read**. That is the one lever
+  here that buys count without buying extent. It is blocked on two mechanical
+  things, both untouched: `LF_BW` is 16 with
+  `assert!(LF_BW * LF_BW == LF_BLOCK_LEN)`, so the scratch has to become
+  rectangular rather than square; and `src/safe_simd/loopfilter_arm.rs:156`
+  asserts `LF_GROUPS == LF_BATCH_MAX`, so the GUARD batch has to be decoupled
+  from the KERNEL batch. Watch `LfScratch::new`'s zero-init while doing it —
+  it runs once per DSP call, ~100 K times a frame.
+* **H's 69.3% needs a different mechanism entirely**, not a bigger batch:
+  §16's cap-lift ratio for it is exactly **1.000**.

--- a/docs/MUT_RECON_KERNELS.md
+++ b/docs/MUT_RECON_KERNELS.md
@@ -962,3 +962,131 @@ is *expensive*: at 8bpc — the common case — t=2/4/8 are at parity and only t
 is measurably positive, at 0.8%.
 
 Every band above overlaps, and every arm-pair ratio here is from a loaded box.
+
+---
+
+# The loop-filter COLUMN band (branch `perf/lf-band`, base `main` @ `0f6bf10`)
+
+Same box: Apple M4 Pro (12 cores, 8P+4E), macOS 26.5.2. Every timed run below
+is wrapped in `measlock`, which takes a cross-agent exclusive lock and then
+waits for the box to go quiet.
+
+§11 priced `LfBlock::fill` and told the next attempt what it had to answer
+first. This section answers it and builds the thing.
+
+## 15. What is NOT done — read this before the parts that work
+
+* **The V pass is untouched.** The band covers `filter_plane_cols_*` (the H
+  pass) only. `fill`'s residual 1,181,034 registrations/frame at t=8 are
+  essentially all V (`filter_plane_rows_*`), and §16 measures that lifting
+  `LF_BATCH_MAX` from 4 to 32 would divide them by **1.971**. That is a
+  separate, smaller, and *much* cheaper change than this one, and it is NOT
+  made here — it needs a rectangular scratch (`LF_BW` is 16 and `LF_BLOCK_LEN`
+  is asserted to be `LF_BW * LF_BW`) and the NEON kernel's
+  `LF_GROUPS == LF_BATCH_MAX` assert decoupled into a guard batch and a kernel
+  batch. Nothing here does any of that.
+* **`cdef_arm`'s 1,863,648 and `ctx.rs:99`'s 2,534,988 are untouched**, as in
+  every prior round. After this branch they are the two largest sites left.
+* **The mirror in `close_band` is NOT covered by the corpus.** §18 plants its
+  removal and **766-vector-subset gate still passes 14/14**. It is kept anyway,
+  because it is what makes "the band never differs from the picture" an
+  invariant rather than an assumption — but the honest statement is that no
+  test here can tell whether it is load-bearing, and the reason it appears
+  inert (a wider filter implies a more distant next edge) is an *argument*, not
+  a measurement.
+* **Not measured, unchanged from §10:** x86_64 and wasm32 (compile-checked
+  only), `asm` / `c-ffi` (the band is dropped there — `call` takes the picture
+  path and the arm is simply unaccelerated), `unchecked`, t=16, any vector
+  below 4K, and any vector with loop restoration live.
+* **The band's copy is not separately priced.** Its cost is inside the A/B
+  below, not isolated from the registrations it removes.
+
+## 16. Attribution: which HALF of `fill` is it, measured
+
+`--features __probe_lf_hist` (new, counts only) splits the site by pass. It
+counts the whole process including `probe_tracker`'s warmup decode, so its raw
+totals are `(iters+1)/iters` of the per-frame figure; at `iters=3` the scale is
+exactly 3/4, and the two halves then sum to 3,835,042 **to the registration**,
+which is the instrument's control.
+
+| t=8, `v4k_8tile` 8bpc | regs/frame | share | regs/open | shape |
+|---|---|---|---|---|
+| H — `filter_plane_cols_*`, vertical edges | **2,656,552** | **69.3%** | 14.30 | `4 * groups` rows x `2 * reach` px |
+| V — `filter_plane_rows_*`, horizontal edges | **1,178,490** | **30.7%** | 6.33 | `2 * reach` rows x `4 * groups` px |
+
+and the run-length histogram says **79% of opens hit the `LF_BATCH_MAX = 4`
+cap exactly** (mean natural run 6.91 H / 7.00 V, with a spike at 32 on V). So
+the obvious lever — fuse harder — was priced from the same run, by counting
+what each natural run WOULD have cost uncapped:
+
+| cap 4 -> 32 | now | uncapped | ratio |
+|---|---|---|---|
+| V | 1,178,490 | 597,876 | **1.971** |
+| H | 2,656,552 | 2,656,552 | **1.000** |
+
+**Exactly 1.000 for H, and that is structural, not a rounding artefact.** The
+H rectangle grows in the ROW direction (`h = 4 * groups`), so a run of `n`
+groups costs `4n` registrations however it is split; the V rectangle grows
+along a picture row (`w = 4 * groups`) at a fixed `h = 2 * reach`, so fusing
+divides its count. **69.3% of the site cannot be bought by fusing along the
+run at all** — only by fusing ACROSS the caller's `x` loop.
+
+## 17. The band, and why it needs no halo
+
+§11b's proposal was a row band with a halo, and its answer was: expressible as
+copy-in/copy-out, NOT as a shared halo, because `&mut` exclusion is static and
+a run-time ownership handoff is a borrow tracker wearing a different hat. It
+also sized the copy at ~3.1 MB per superblock row and ~53 MB per frame, and
+said to check that arithmetic before writing any conversion.
+
+**The halo question does not arise here, because this band never owns
+anything.** `src/lf_band.rs`:
+
+* `LfBand::fill_from` copies `4 * len` picture rows x `4 * w + 14` pixels into
+  a plain `Vec<BD::Pixel>` — **one immutable guard per picture row, over a
+  CONTIGUOUS span**, once per superblock, for all of that superblock's `x`
+  positions.
+* `LfBlock::open_band` / `fill_band` read the rectangle out of that `Vec`. No
+  guard, no tracker, no policy branch.
+* `LfBlock::close_band` writes each changed span **to the picture, with the
+  same mutable guard `close` always took**, and mirrors it into the band.
+
+So the band is a read CACHE that is equal to the picture at every point, which
+is what makes `open_band` returning `None` (rectangle off the plane, band too
+small) *ordinary* rather than a special case: the caller falls through to the
+picture path and reads identical bytes. Nothing is handed between workers, so
+there is no halo protocol to express.
+
+**The copy is 170x smaller than §11b's sizing** because the unit is a
+superblock, not a superblock row: 128 rows x 142 px is ~18 KB at 8bpc, against
+3.1 MB. And it is not even net-new traffic — the per-edge windows it replaces
+are 14 px wide every 4 px, i.e. ~3.5x redundant.
+
+### Registrations, measured — `--features probe-sites`, `lost=0`
+
+One binary, `RAV1D_LF_BAND=0/1`. `v4k_8tile` 8bpc t=8:
+
+| site | band OFF | band ON |
+|---|---|---|
+| whole decoder | **11,401,399** | **8,941,599** |
+| `LfBlock::fill` | 3,835,042 | 1,181,034 |
+| `LfBand::fill_from` (copy-in) | 0 | 194,208 @ **142 B** |
+| `LfBlock::close` (write) | 17,852 | 12,616 |
+| `LfBlock::close_band` (write) | 0 | 5,236 |
+
+Three things to read off it:
+
+1. The band-off column **reproduces §11a's 11,401,399 exactly**, so the
+   `Option` threaded through the dispatch changes no registration anywhere.
+2. `fill` falls by **2,654,008**, against the 2,656,552 §16 attributed to the H
+   pass — i.e. 99.9% of the H pass is banded and the residual 2,544 are opens
+   that declined. The remainder of `fill` is the V pass, untouched.
+3. **The write population is identical: 17,852 = 12,616 + 5,236.** The only
+   MUTABLE reservation in the loop filter is bit-for-bit what it was, merely
+   split across two functions. Nothing here widens a mutable extent — which is
+   the direction #479 and #469 were burned by.
+
+Net **-2,459,800 registrations/frame, -21.6% of the whole decoder's
+population**, bought at an extent of 142 contiguous bytes per guard. That is
+the opposite trade from §11c's hull, which removed 3.46 M by paying 50-60 KB
+of strided extent and measured **2.65x SLOWER**.

--- a/examples/probe_tracker.rs
+++ b/examples/probe_tracker.rs
@@ -83,6 +83,10 @@ fn main() {
     {
         print!("{}", rav1d_disjoint_mut::site_probe::report(iters));
     }
+    #[cfg(feature = "__probe_lf_hist")]
+    {
+        print!("{}", rav1d_safe::src::loopfilter::lf_hist::report(iters as usize));
+    }
     #[cfg(not(any(feature = "probe-count", feature = "probe-wide")))]
     eprintln!("(built without --features probe-count / probe-wide; no counters)");
 

--- a/lib.rs
+++ b/lib.rs
@@ -132,7 +132,13 @@ pub mod src {
     mod filmgrain;
     mod ipred;
     mod itx;
+    pub(crate) mod lf_band;
     mod lf_mask;
+    // `pub` only to let `examples/probe_tracker` reach `loopfilter::lf_hist`.
+    // The default build keeps it private.
+    #[cfg(feature = "__probe_lf_hist")]
+    pub mod loopfilter;
+    #[cfg(not(feature = "__probe_lf_hist"))]
     mod loopfilter;
     mod looprestoration;
     mod mc;

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -9,6 +9,11 @@ use crate::src::disjoint_mut::DisjointMut;
 use crate::src::internal::Rav1dBitDepthDSPContext;
 use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dFrameData;
+use crate::src::lf_band::lf_band_enabled;
+use crate::src::lf_band::LfBand;
+use crate::src::lf_band::LF_BAND_MAX_COLS;
+use crate::src::lf_band::LF_BAND_MAX_ROWS;
+use crate::src::lf_band::LF_BAND_PAD;
 use crate::src::lr_apply::LrRestorePlanes;
 use crate::src::relaxed_atomic::RelaxedAtomic;
 use crate::src::strided::Strided as _;
@@ -365,6 +370,35 @@ pub(crate) fn rav1d_copy_lpf<BD: BitDepth>(
     }
 }
 
+
+/// Fill `band` for one superblock's column pass, or leave it disarmed.
+///
+/// Split out so the luma and chroma callers cannot arm it on different terms.
+#[inline]
+fn arm_band<BD: BitDepth>(
+    band: &mut LfBand<BD>,
+    dst: PicOffset,
+    pic_stride: isize,
+    rows: usize,
+    cols: usize,
+) {
+    if !(lf_band_enabled() && band.fill_from(dst, pic_stride, rows, cols)) {
+        band.disarm();
+    }
+}
+
+/// `(band buffer, band offset of column `4 * x`, band row stride)` for one
+/// `loop_filter_sb128` call, or `None` when the band is disarmed.
+#[inline]
+fn band_cursor<BD: BitDepth>(
+    band: &mut LfBand<BD>,
+    x: usize,
+) -> Option<(&mut [BD::Pixel], usize, isize)> {
+    band.view().map(|v| {
+        let off = LF_BAND_PAD + 4 * x;
+        (v.buf, off, v.stride)
+    })
+}
 #[inline]
 fn filter_plane_cols_y<BD: BitDepth>(
     f: &Rav1dFrameData,
@@ -375,12 +409,19 @@ fn filter_plane_cols_y<BD: BitDepth>(
     w: usize,
     starty4: usize,
     endy4: usize,
+    band: &mut LfBand<BD>,
 ) {
     // filter edges between columns (e.g. block1 | block2)
     let lf_sb = &f.dsp.lf.loop_filter_sb;
     let len = endy4 - starty4;
+    let pic_stride = y_dst.pixel_stride::<BD>();
     let y_dst = |x| y_dst + x * 4;
     assert!(y_dst(w).offset <= y_dst(w).data.pixel_len::<BD>()); // Bounds check
+    // ONE immutable guard per picture row for the whole superblock, in place
+    // of `4 * groups` guards per filtered column. Declining leaves the band
+    // disarmed and every call on the picture path, which is correct because
+    // the band never holds anything the picture does not.
+    arm_band::<BD>(band, y_dst(0), pic_stride, 4 * len, 4 * w + 2 * LF_BAND_PAD);
     let mask = &mask[..w];
     for x in 0..w {
         if !have_left && x == 0 {
@@ -398,10 +439,11 @@ fn filter_plane_cols_y<BD: BitDepth>(
             mask.each_ref().map(|[_, b]| b.get() as u32)
         };
         let lvl = |y| lvl + (4 * x + y);
+        let cursor = band_cursor::<BD>(band, x);
         lf_sb
             .y
             .h
-            .call::<BD>(f, y_dst(x), &hmask, lvl(0), len, true, false);
+            .call::<BD>(f, y_dst(x), &hmask, lvl(0), len, true, false, cursor);
     }
 }
 
@@ -436,7 +478,7 @@ fn filter_plane_rows_y<BD: BitDepth>(
         lf_sb
             .y
             .v
-            .call::<BD>(f, y_dst(i), &vmask, lvl(1), w, true, true);
+            .call::<BD>(f, y_dst(i), &vmask, lvl(1), w, true, true, None);
     }
 }
 
@@ -452,12 +494,17 @@ fn filter_plane_cols_uv<BD: BitDepth>(
     starty4: usize,
     endy4: usize,
     ss_ver: c_int,
+    [u_band, v_band]: &mut [LfBand<BD>; 2],
 ) {
     // filter edges between columns (e.g. block1 | block2)
     let lf_sb = &f.dsp.lf.loop_filter_sb;
     let len = endy4 - starty4;
+    let pic_stride = u_dst.pixel_stride::<BD>();
     let u_dst = |x| u_dst + x * 4;
     let v_dst = |x| v_dst + x * 4;
+    let (rows, cols) = (4 * len, 4 * w + 2 * LF_BAND_PAD);
+    arm_band::<BD>(u_band, u_dst(0), pic_stride, rows, cols);
+    arm_band::<BD>(v_band, v_dst(0), pic_stride, rows, cols);
     assert!(u_dst(w).offset <= u_dst(w).data.pixel_len::<BD>()); // Bounds check
     assert!(v_dst(w).offset <= v_dst(w).data.pixel_len::<BD>()); // Bounds check
     let mask = &mask[..w];
@@ -478,14 +525,16 @@ fn filter_plane_cols_uv<BD: BitDepth>(
         };
         let hmask = [hmask[0], hmask[1], 0];
         let lvl = |y| lvl + (4 * x + y);
+        let uc = band_cursor::<BD>(u_band, x);
         lf_sb
             .uv
             .h
-            .call::<BD>(f, u_dst(x), &hmask, lvl(2), len, false, false);
+            .call::<BD>(f, u_dst(x), &hmask, lvl(2), len, false, false, uc);
+        let vc = band_cursor::<BD>(v_band, x);
         lf_sb
             .uv
             .h
-            .call::<BD>(f, v_dst(x), &hmask, lvl(3), len, false, false);
+            .call::<BD>(f, v_dst(x), &hmask, lvl(3), len, false, false, vc);
     }
 }
 
@@ -525,11 +574,11 @@ fn filter_plane_rows_uv<BD: BitDepth>(
         lf_sb
             .uv
             .v
-            .call::<BD>(f, u_dst(i), &vmask, lvl(2), w, false, true);
+            .call::<BD>(f, u_dst(i), &vmask, lvl(2), w, false, true, None);
         lf_sb
             .uv
             .v
-            .call::<BD>(f, v_dst(i), &vmask, lvl(3), w, false, true);
+            .call::<BD>(f, v_dst(i), &vmask, lvl(3), w, false, true, None);
     }
 }
 
@@ -646,6 +695,12 @@ pub(crate) fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
         offset: 4 * f.b4_stride as usize * (sby * sbsz) as usize,
     };
     have_left = false;
+    // Allocated once per sbrow (17 per frame at 4K) and reused across every
+    // superblock and both chroma planes below.
+    let mut bands: [LfBand<BD>; 2] = [
+        LfBand::with_capacity(LF_BAND_MAX_ROWS, LF_BAND_MAX_COLS),
+        LfBand::with_capacity(LF_BAND_MAX_ROWS, LF_BAND_MAX_COLS),
+    ];
     for x in 0..f.sb128w as usize {
         filter_plane_cols_y::<BD>(
             f,
@@ -656,6 +711,7 @@ pub(crate) fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
             cmp::min(32, f.w4 - x as c_int * 32) as usize,
             starty4 as usize,
             endy4 as usize,
+            &mut bands[0],
         );
         have_left = true;
     }
@@ -679,6 +735,7 @@ pub(crate) fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
             starty4 as usize >> ss_ver,
             uv_endy4 as usize,
             ss_ver,
+            &mut bands,
         );
         have_left = true;
     }

--- a/src/lf_apply.rs
+++ b/src/lf_apply.rs
@@ -11,8 +11,8 @@ use crate::src::internal::Rav1dContext;
 use crate::src::internal::Rav1dFrameData;
 use crate::src::lf_band::lf_band_enabled;
 use crate::src::lf_band::LfBand;
-use crate::src::lf_band::LF_BAND_MAX_COLS;
-use crate::src::lf_band::LF_BAND_MAX_ROWS;
+use crate::src::lf_band::LfBandCursor;
+use crate::src::lf_band::LF_BAND_MAX_DIM;
 use crate::src::lf_band::LF_BAND_PAD;
 use crate::src::lr_apply::LrRestorePlanes;
 use crate::src::relaxed_atomic::RelaxedAtomic;
@@ -381,22 +381,31 @@ fn arm_band<BD: BitDepth>(
     pic_stride: isize,
     rows: usize,
     cols: usize,
+    row_pad: usize,
+    col_pad: usize,
 ) {
-    if !(lf_band_enabled() && band.fill_from(dst, pic_stride, rows, cols)) {
+    if !(lf_band_enabled() && band.fill_from(dst, pic_stride, rows, cols, row_pad, col_pad)) {
         band.disarm();
     }
 }
 
-/// `(band buffer, band offset of column `4 * x`, band row stride)` for one
-/// `loop_filter_sb128` call, or `None` when the band is disarmed.
+/// A cursor anchored at the band cell one `loop_filter_sb128` call names as
+/// its `dst`, or `None` when the band is disarmed.
+///
+/// The H band pads on columns and indexes rows from 0; the V band pads on rows
+/// and indexes columns from 0.
 #[inline]
 fn band_cursor<BD: BitDepth>(
     band: &mut LfBand<BD>,
-    x: usize,
-) -> Option<(&mut [BD::Pixel], usize, isize)> {
-    band.view().map(|v| {
-        let off = LF_BAND_PAD + 4 * x;
-        (v.buf, off, v.stride)
+    row: usize,
+    col: usize,
+) -> Option<LfBandCursor<'_, BD>> {
+    band.view().map(|v| LfBandCursor {
+        buf: v.buf,
+        row,
+        col,
+        stride: v.stride,
+        rows: v.rows,
     })
 }
 #[inline]
@@ -421,7 +430,7 @@ fn filter_plane_cols_y<BD: BitDepth>(
     // of `4 * groups` guards per filtered column. Declining leaves the band
     // disarmed and every call on the picture path, which is correct because
     // the band never holds anything the picture does not.
-    arm_band::<BD>(band, y_dst(0), pic_stride, 4 * len, 4 * w + 2 * LF_BAND_PAD);
+    arm_band::<BD>(band, y_dst(0), pic_stride, 4 * len, 4 * w + 2 * LF_BAND_PAD, 0, LF_BAND_PAD);
     let mask = &mask[..w];
     for x in 0..w {
         if !have_left && x == 0 {
@@ -439,7 +448,7 @@ fn filter_plane_cols_y<BD: BitDepth>(
             mask.each_ref().map(|[_, b]| b.get() as u32)
         };
         let lvl = |y| lvl + (4 * x + y);
-        let cursor = band_cursor::<BD>(band, x);
+        let cursor = band_cursor::<BD>(band, 0, LF_BAND_PAD + 4 * x);
         lf_sb
             .y
             .h
@@ -458,14 +467,27 @@ fn filter_plane_rows_y<BD: BitDepth>(
     w: usize,
     starty4: usize,
     endy4: usize,
+    band: &mut LfBand<BD>,
 ) {
     //                                 block1
     // filter edges between rows (e.g. ------)
     //                                 block2
     let lf_sb = &f.dsp.lf.loop_filter_sb;
     let len = endy4 - starty4;
+    let pic_stride = y_dst.pixel_stride::<BD>();
     let y_dst = |i| y_dst + (i as isize * 4 * y_dst.pixel_stride::<BD>());
     assert!(y_dst(len - 1).offset <= y_dst(len - 1).data.pixel_len::<BD>()); // Bounds check
+    // The V rectangle reaches `+-reach` ROWS, so this band pads on rows and
+    // spans the superblock's columns exactly.
+    arm_band::<BD>(
+        band,
+        y_dst(0),
+        pic_stride,
+        4 * len + 2 * LF_BAND_PAD,
+        4 * w,
+        LF_BAND_PAD,
+        0,
+    );
     for i in 0..len {
         let y = i + starty4;
         if !have_top && y == 0 {
@@ -475,10 +497,11 @@ fn filter_plane_rows_y<BD: BitDepth>(
             .each_ref()
             .map(|[a, b]| a.get() as u32 | ((b.get() as u32) << 16));
         let lvl = |y| lvl + (4 * i * b4_stride + y);
+        let cursor = band_cursor::<BD>(band, LF_BAND_PAD + 4 * i, 0);
         lf_sb
             .y
             .v
-            .call::<BD>(f, y_dst(i), &vmask, lvl(1), w, true, true, None);
+            .call::<BD>(f, y_dst(i), &vmask, lvl(1), w, true, true, cursor);
     }
 }
 
@@ -499,12 +522,16 @@ fn filter_plane_cols_uv<BD: BitDepth>(
     // filter edges between columns (e.g. block1 | block2)
     let lf_sb = &f.dsp.lf.loop_filter_sb;
     let len = endy4 - starty4;
-    let pic_stride = u_dst.pixel_stride::<BD>();
+    // Per plane: U and V share a stride in every layout dav1d produces, but
+    // the band's row walk is wrong by a whole plane if that ever stops being
+    // true, so neither is derived from the other.
+    let u_stride = u_dst.pixel_stride::<BD>();
+    let v_stride = v_dst.pixel_stride::<BD>();
     let u_dst = |x| u_dst + x * 4;
     let v_dst = |x| v_dst + x * 4;
     let (rows, cols) = (4 * len, 4 * w + 2 * LF_BAND_PAD);
-    arm_band::<BD>(u_band, u_dst(0), pic_stride, rows, cols);
-    arm_band::<BD>(v_band, v_dst(0), pic_stride, rows, cols);
+    arm_band::<BD>(u_band, u_dst(0), u_stride, rows, cols, 0, LF_BAND_PAD);
+    arm_band::<BD>(v_band, v_dst(0), v_stride, rows, cols, 0, LF_BAND_PAD);
     assert!(u_dst(w).offset <= u_dst(w).data.pixel_len::<BD>()); // Bounds check
     assert!(v_dst(w).offset <= v_dst(w).data.pixel_len::<BD>()); // Bounds check
     let mask = &mask[..w];
@@ -525,12 +552,12 @@ fn filter_plane_cols_uv<BD: BitDepth>(
         };
         let hmask = [hmask[0], hmask[1], 0];
         let lvl = |y| lvl + (4 * x + y);
-        let uc = band_cursor::<BD>(u_band, x);
+        let uc = band_cursor::<BD>(u_band, 0, LF_BAND_PAD + 4 * x);
         lf_sb
             .uv
             .h
             .call::<BD>(f, u_dst(x), &hmask, lvl(2), len, false, false, uc);
-        let vc = band_cursor::<BD>(v_band, x);
+        let vc = band_cursor::<BD>(v_band, 0, LF_BAND_PAD + 4 * x);
         lf_sb
             .uv
             .h
@@ -551,14 +578,20 @@ fn filter_plane_rows_uv<BD: BitDepth>(
     starty4: usize,
     endy4: usize,
     ss_hor: c_int,
+    [u_band, v_band]: &mut [LfBand<BD>; 2],
 ) {
     //                                 block1
     // filter edges between rows (e.g. ------)
     //                                 block2
     let lf_sb = &f.dsp.lf.loop_filter_sb;
     let len = endy4 - starty4;
+    let u_stride = u_dst.pixel_stride::<BD>();
+    let v_stride = v_dst.pixel_stride::<BD>();
     let u_dst = |i| u_dst + (i as isize * 4 * u_dst.pixel_stride::<BD>());
     let v_dst = |i| v_dst + (i as isize * 4 * v_dst.pixel_stride::<BD>());
+    let (rows, cols) = (4 * len + 2 * LF_BAND_PAD, 4 * w);
+    arm_band::<BD>(u_band, u_dst(0), u_stride, rows, cols, LF_BAND_PAD, 0);
+    arm_band::<BD>(v_band, v_dst(0), v_stride, rows, cols, LF_BAND_PAD, 0);
     assert!(u_dst(len - 1).offset <= u_dst(len - 1).data.pixel_len::<BD>()); // Bounds check
     assert!(v_dst(len - 1).offset <= v_dst(len - 1).data.pixel_len::<BD>()); // Bounds check
     for i in 0..len {
@@ -571,14 +604,16 @@ fn filter_plane_rows_uv<BD: BitDepth>(
             .map(|[a, b]| a.get() as u32 | ((b.get() as u32) << (16 >> ss_hor)));
         let vmask = [vmask[0], vmask[1], 0];
         let lvl = |y| lvl + (4 * i * b4_stride + y);
+        let uc = band_cursor::<BD>(u_band, LF_BAND_PAD + 4 * i, 0);
+        let vc = band_cursor::<BD>(v_band, LF_BAND_PAD + 4 * i, 0);
         lf_sb
             .uv
             .v
-            .call::<BD>(f, u_dst(i), &vmask, lvl(2), w, false, true, None);
+            .call::<BD>(f, u_dst(i), &vmask, lvl(2), w, false, true, uc);
         lf_sb
             .uv
             .v
-            .call::<BD>(f, v_dst(i), &vmask, lvl(3), w, false, true, None);
+            .call::<BD>(f, v_dst(i), &vmask, lvl(3), w, false, true, vc);
     }
 }
 
@@ -698,8 +733,8 @@ pub(crate) fn rav1d_loopfilter_sbrow_cols<BD: BitDepth>(
     // Allocated once per sbrow (17 per frame at 4K) and reused across every
     // superblock and both chroma planes below.
     let mut bands: [LfBand<BD>; 2] = [
-        LfBand::with_capacity(LF_BAND_MAX_ROWS, LF_BAND_MAX_COLS),
-        LfBand::with_capacity(LF_BAND_MAX_ROWS, LF_BAND_MAX_COLS),
+        LfBand::with_capacity(LF_BAND_MAX_DIM, LF_BAND_MAX_DIM),
+        LfBand::with_capacity(LF_BAND_MAX_DIM, LF_BAND_MAX_DIM),
     ];
     for x in 0..f.sb128w as usize {
         filter_plane_cols_y::<BD>(
@@ -764,6 +799,12 @@ pub(crate) fn rav1d_loopfilter_sbrow_rows<BD: BitDepth>(
         data: &f.lf.level[..],
         offset: 4 * f.b4_stride as usize * (sby * sbsz) as usize,
     };
+    // Allocated once per sbrow and reused across every superblock and both
+    // chroma planes below, as in `rav1d_loopfilter_sbrow_cols`.
+    let mut bands: [LfBand<BD>; 2] = [
+        LfBand::with_capacity(LF_BAND_MAX_DIM, LF_BAND_MAX_DIM),
+        LfBand::with_capacity(LF_BAND_MAX_DIM, LF_BAND_MAX_DIM),
+    ];
     for x in 0..f.sb128w as usize {
         filter_plane_rows_y::<BD>(
             f,
@@ -775,6 +816,7 @@ pub(crate) fn rav1d_loopfilter_sbrow_rows<BD: BitDepth>(
             cmp::min(32, f.w4 - x as c_int * 32) as usize,
             starty4 as usize,
             endy4 as usize,
+            &mut bands[0],
         );
     }
 
@@ -801,6 +843,7 @@ pub(crate) fn rav1d_loopfilter_sbrow_rows<BD: BitDepth>(
             starty4 as usize >> ss_ver,
             uv_endy4 as usize,
             ss_hor,
+            &mut bands,
         );
     }
 }

--- a/src/lf_band.rs
+++ b/src/lf_band.rs
@@ -73,17 +73,66 @@ use crate::src::loopfilter::LF_TAP_REACH;
 /// pixels before it and ends the same distance after the last edge.
 pub(crate) const LF_BAND_PAD: usize = LF_TAP_REACH as usize;
 
-/// Runtime A/B switch, default **ON**: `RAV1D_LF_BAND=0` makes every column
-/// call take the picture path.
+/// Whether a band may be armed at all.
 ///
-/// One binary, two arms — the `RAV1D_OWNED_RECON` convention this campaign
-/// uses so that an A/B pair cannot differ in anything but the arm. Disarmed,
-/// the only residual is the `Option` argument threaded through the dispatch,
-/// which is what the `bandoff`-vs-`main` column of the measurement prices.
+/// # The band is REFUTED under tile threading — measured, not argued
+///
+/// A band takes ONE immutable guard per picture row over a CONTIGUOUS span.
+/// The loop filter's read set is not contiguous: it is the 2-D SPARSE union of
+/// `+-reach` tap windows around the edges that actually filter, and a row in
+/// which nothing filters is not read at all. So any per-row span
+/// over-reserves — columns no call reads, in rows some call does.
+///
+/// Under tile threading that over-reservation collides with legitimate
+/// concurrent narrow writes. Measured on the 8-bit/data group (358 vectors) at
+/// `--threads 8`, `examples/md5_inventory`:
+///
+/// | arm | pass | error |
+/// |---|---|---|
+/// | band off | 358 | 0 |
+/// | band off (repeat) | 358 | 0 |
+/// | column band only | 357 / 356 / 358 | **1 / 2 / 0** |
+/// | column + row band | 294 | **64** |
+///
+/// — i.e. NONDETERMINISTIC decode failures, and the recorded overlap is
+///
+/// ```text
+/// current:  &     _[163840..163968]   <- the band's 128-px row copy-in
+/// existing: &mut  _[163944..163952]   <- a concurrent 8-px write inside it
+/// ```
+///
+/// The first `--threads 8` corpus run of the column-only band passed 753/755
+/// CLEAN. **That was one lucky sample**, which is exactly why "766 vectors
+/// passed" is evidence and not a proof.
+///
+/// This is the third refutation of "cut the guard COUNT by widening the
+/// reservation" in this campaign, and the first where the widening was
+/// CONTIGUOUS rather than the strided hull's inter-row gaps
+/// (`docs/MUT_RECON_KERNELS.md` §11c).
+///
+/// # And the obvious gate does NOT rescue it
+///
+/// `tile_threading_active()` — the latch that already lets `fill_hull`,
+/// `block_mut` and `compact_read` widen a reservation — was tried and is the
+/// WRONG condition here. It gates against concurrent TILE workers, but the
+/// loop filter's concurrency is between SBROW FILTER TASKS, which exist
+/// whenever `n_tc > 1` however many tiles a frame has
+/// (`src/thread_task.rs:1030-1043`: the task for `sby+1` is inserted before
+/// the selected one runs). Gated that way the census at `--threads 8` is
+/// byte-identical to `main` (11,401,399, so the band provably never armed on
+/// `v4k_8tile`), and the 8-bit/data group STILL produced 8 errors in one run
+/// of two — against 0/0/0 on the base commit's own binary, same group, same
+/// box, same load.
+///
+/// So the band ships **default OFF**, opt-in with `RAV1D_LF_BAND=1`, in the
+/// shape `__probe_lf_hull` already uses for the strided-hull negative: a
+/// reproduction, not a policy. A gate that is right for this site would have
+/// to be "no other thread can be filtering this picture", which is not a
+/// condition the decoder currently exposes.
 pub(crate) fn lf_band_enabled() -> bool {
     use std::sync::OnceLock;
-    static ON: OnceLock<bool> = OnceLock::new();
-    *ON.get_or_init(|| !matches!(std::env::var("RAV1D_LF_BAND").as_deref(), Ok("0")))
+    static ENV: OnceLock<bool> = OnceLock::new();
+    *ENV.get_or_init(|| matches!(std::env::var("RAV1D_LF_BAND").as_deref(), Ok("1")))
 }
 
 /// Widest band either pass needs, on either axis.

--- a/src/lf_band.rs
+++ b/src/lf_band.rs
@@ -1,0 +1,190 @@
+//! A per-superblock read cache for the loop filter's COLUMN pass.
+//!
+//! # What this is for
+//!
+//! `LfBlock::fill` is the largest single borrow-registration site in the
+//! decoder: 3,835,042 per frame on `v4k_8tile` 8bpc at `--threads 8`, 33.6% of
+//! the whole decoder's 11,401,399 (`docs/MUT_RECON_KERNELS.md` §11a). Measured
+//! here with `--features __probe_lf_hist`, that population splits
+//! **69.3% / 30.7%** between the two passes, and the two halves have completely
+//! different shapes:
+//!
+//! | pass | rectangle | registrations |
+//! |---|---|---|
+//! | H — `filter_plane_cols_*`, vertical edges | `4 * groups` rows x `2 * reach` px | `4 * groups` |
+//! | V — `filter_plane_rows_*`, horizontal edges | `2 * reach` rows x `4 * groups` px | `2 * reach` |
+//!
+//! Fusing `n` groups divides the V pass's cost by `n` and does nothing at all
+//! for the H pass, whose rectangle grows in the ROW direction — one guard per
+//! picture row per group, no matter how the run fuses. That is measured, not
+//! argued: with the [`LF_BATCH_MAX`](super::loopfilter::LF_BATCH_MAX) cap
+//! lifted to 32 the V pass's registrations fall by **1.971x** and the H pass's
+//! by **1.000x**.
+//!
+//! So the H pass's 2.66 M/frame can only be cut by fusing ACROSS the caller's
+//! `x` loop, and that is what this does.
+//!
+//! # The shape, and why it needs no halo handshake
+//!
+//! `docs/MUT_RECON_KERNELS.md` §11b asked whether a filter band could own a
+//! row band with a HALO shared with its neighbour, and answered: not in safe
+//! Rust, because `&mut` exclusion is a static fact and a run-time ownership
+//! handoff is a borrow tracker wearing a different hat.
+//!
+//! This band sidesteps that question entirely, because **it is a read cache,
+//! not an owner.** `LfBlock::close_band` writes each changed span to the
+//! PICTURE exactly as `LfBlock::close` always has — same mutable guard, same
+//! extent, same 17,852 write registrations per frame — and additionally
+//! mirrors it into the band so the next `x` in the same superblock sees it.
+//! The band is therefore never authoritative and never diverges from the
+//! picture:
+//!
+//! * nothing is ever "handed over", so no halo protocol is needed;
+//! * any call may fall back to the picture path at any point and read the same
+//!   bytes — which is what makes `open_band` returning `None` (band too small,
+//!   rectangle off the plane) simply correct rather than a special case;
+//! * the write population, the only MUTABLE one, is bit-for-bit unchanged.
+//!
+//! The one reservation this widens is the IMMUTABLE read: one guard per
+//! picture row over `4 * w + 14` contiguous pixels, instead of one guard per
+//! picture row per filtered column over `2 * reach`. Contiguous within a row,
+//! ~150 bytes — nowhere near the 50-60 KB strided hull that measured 2.65x
+//! SLOWER at t=8 (§11c). The hull's cost was its EXTENT crossing the tracker's
+//! wide path; this pays no extent for the count it buys, which is the gap
+//! §11d/§11f named.
+//!
+//! # Ordering
+//!
+//! The H pass is sequentially dependent along `x`: filtering at `4x` writes
+//! pixels that the window at `4(x+1)` reads. The band preserves that exactly —
+//! reads and writes go through it in the same order they went through the
+//! picture. Across superblocks the dependency also holds, because each band is
+//! filled at the start of its own superblock, after the previous superblock's
+//! writes have already landed in the picture.
+
+use crate::include::common::bitdepth::BitDepth;
+use crate::include::dav1d::picture::PicOffset;
+use crate::src::loopfilter::LF_TAP_REACH;
+
+/// Columns of margin on each side of the superblock, in pixels.
+///
+/// The widest tap window is `+-LF_TAP_REACH`, and the leftmost filtered edge
+/// sits at the superblock's own left column, so the band starts `LF_TAP_REACH`
+/// pixels before it and ends the same distance after the last edge.
+pub(crate) const LF_BAND_PAD: usize = LF_TAP_REACH as usize;
+
+/// Runtime A/B switch, default **ON**: `RAV1D_LF_BAND=0` makes every column
+/// call take the picture path.
+///
+/// One binary, two arms — the `RAV1D_OWNED_RECON` convention this campaign
+/// uses so that an A/B pair cannot differ in anything but the arm. Disarmed,
+/// the only residual is the `Option` argument threaded through the dispatch,
+/// which is what the `bandoff`-vs-`main` column of the measurement prices.
+pub(crate) fn lf_band_enabled() -> bool {
+    use std::sync::OnceLock;
+    static ON: OnceLock<bool> = OnceLock::new();
+    *ON.get_or_init(|| !matches!(std::env::var("RAV1D_LF_BAND").as_deref(), Ok("0")))
+}
+
+/// Widest band any superblock needs: `4 * 32` picture rows by `4 * 32` columns
+/// plus [`LF_BAND_PAD`] on each side.
+pub(crate) const LF_BAND_MAX_ROWS: usize = 128;
+pub(crate) const LF_BAND_MAX_COLS: usize = 4 * 32 + 2 * LF_BAND_PAD;
+
+/// Reusable scratch for one superblock's column pass.
+///
+/// Allocated once per `rav1d_loopfilter_sbrow_cols` call (17 per frame at 4K)
+/// and reused across every superblock and both chroma planes in it, so the
+/// decode path takes no per-superblock allocation.
+pub(crate) struct LfBand<BD: BitDepth> {
+    buf: Vec<BD::Pixel>,
+    /// Live row stride, in pixels. `0` when the band is not filled.
+    stride: usize,
+    /// Live row count. `0` when the band is not filled.
+    rows: usize,
+}
+
+impl<BD: BitDepth> LfBand<BD> {
+    /// Capacity for `max_rows x max_cols`, zero-filled once.
+    pub(crate) fn with_capacity(max_rows: usize, max_cols: usize) -> Self {
+        Self {
+            buf: vec![0u8.into(); max_rows * max_cols],
+            stride: 0,
+            rows: 0,
+        }
+    }
+
+    /// Fill from the picture: `rows` picture rows starting at `dst`'s row,
+    /// each `cols` pixels wide starting [`LF_BAND_PAD`] pixels left of `dst`.
+    ///
+    /// ONE immutable guard per picture row, over a CONTIGUOUS span — this is
+    /// the whole registration cost of the pass that replaces
+    /// `4 * groups` guards per filtered column.
+    ///
+    /// Returns `false` — leaving the band disarmed, so callers use the picture
+    /// path — when the rectangle would leave the plane or exceed the capacity
+    /// this band was built with. That is a correctness-free decision: the band
+    /// is only ever a cache of what the picture already holds.
+    pub(crate) fn fill_from(
+        &mut self,
+        dst: PicOffset,
+        pic_stride: isize,
+        rows: usize,
+        cols: usize,
+    ) -> bool {
+        self.stride = 0;
+        self.rows = 0;
+        if rows == 0 || cols == 0 || rows * cols > self.buf.len() {
+            return false;
+        }
+        let first = match (dst.offset as isize).checked_sub(LF_BAND_PAD as isize) {
+            Some(v) if v >= 0 => v,
+            _ => return false,
+        };
+        // Row offsets are monotone in `r`, so checking the two ends bounds all
+        // of them — including a negative picture stride.
+        let last = first + (rows as isize - 1) * pic_stride;
+        let plane = dst.data.pixel_len::<BD>() as isize;
+        if first.min(last) < 0 || first.max(last) + cols as isize > plane {
+            return false;
+        }
+        for r in 0..rows {
+            let off = (first + r as isize * pic_stride) as usize;
+            let guard = PicOffset {
+                data: dst.data,
+                offset: off,
+            }
+            .slice::<BD>(cols);
+            self.buf[r * cols..][..cols].copy_from_slice(&guard);
+        }
+        self.stride = cols;
+        self.rows = rows;
+        true
+    }
+
+    /// Disarm without filling, so every call takes the picture path.
+    pub(crate) fn disarm(&mut self) {
+        self.stride = 0;
+        self.rows = 0;
+    }
+
+    /// The live band, or `None` when disarmed.
+    #[inline(always)]
+    pub(crate) fn view(&mut self) -> Option<LfBandView<'_, BD>> {
+        if self.stride == 0 {
+            return None;
+        }
+        Some(LfBandView {
+            stride: self.stride as isize,
+            buf: &mut self.buf[..self.rows * self.stride],
+        })
+    }
+}
+
+/// A filled band, handed to one `loop_filter_sb128` call.
+pub(crate) struct LfBandView<'c, BD: BitDepth> {
+    pub(crate) buf: &'c mut [BD::Pixel],
+    /// Row stride in pixels — also the band's column count.
+    pub(crate) stride: isize,
+}
+

--- a/src/lf_band.rs
+++ b/src/lf_band.rs
@@ -86,10 +86,13 @@ pub(crate) fn lf_band_enabled() -> bool {
     *ON.get_or_init(|| !matches!(std::env::var("RAV1D_LF_BAND").as_deref(), Ok("0")))
 }
 
-/// Widest band any superblock needs: `4 * 32` picture rows by `4 * 32` columns
-/// plus [`LF_BAND_PAD`] on each side.
-pub(crate) const LF_BAND_MAX_ROWS: usize = 128;
-pub(crate) const LF_BAND_MAX_COLS: usize = 4 * 32 + 2 * LF_BAND_PAD;
+/// Widest band either pass needs, on either axis.
+///
+/// A superblock is at most `4 * 32` pixels on a side, and the padded axis adds
+/// [`LF_BAND_PAD`] at each end — columns for the H pass, rows for the V pass.
+/// One square capacity covers both orientations, so the same buffer can be
+/// reused by either without a re-check that depends on which pass has it.
+pub(crate) const LF_BAND_MAX_DIM: usize = 4 * 32 + 2 * LF_BAND_PAD;
 
 /// Reusable scratch for one superblock's column pass.
 ///
@@ -114,8 +117,14 @@ impl<BD: BitDepth> LfBand<BD> {
         }
     }
 
-    /// Fill from the picture: `rows` picture rows starting at `dst`'s row,
-    /// each `cols` pixels wide starting [`LF_BAND_PAD`] pixels left of `dst`.
+    /// Fill from the picture: `rows` picture rows starting `row_pad` rows
+    /// ABOVE `dst`'s row, each `cols` pixels wide starting `col_pad` pixels
+    /// left of `dst`.
+    ///
+    /// The two passes pad on different axes — the H pass reads `+-reach`
+    /// columns at the rows it filters, the V pass reads `+-reach` rows at the
+    /// columns it filters — so the pad is a parameter rather than a constant
+    /// on one axis.
     ///
     /// ONE immutable guard per picture row, over a CONTIGUOUS span — this is
     /// the whole registration cost of the pass that replaces
@@ -131,16 +140,18 @@ impl<BD: BitDepth> LfBand<BD> {
         pic_stride: isize,
         rows: usize,
         cols: usize,
+        row_pad: usize,
+        col_pad: usize,
     ) -> bool {
         self.stride = 0;
         self.rows = 0;
         if rows == 0 || cols == 0 || rows * cols > self.buf.len() {
             return false;
         }
-        let first = match (dst.offset as isize).checked_sub(LF_BAND_PAD as isize) {
-            Some(v) if v >= 0 => v,
-            _ => return false,
-        };
+        let first = dst.offset as isize - row_pad as isize * pic_stride - col_pad as isize;
+        if first < 0 {
+            return false;
+        }
         // Row offsets are monotone in `r`, so checking the two ends bounds all
         // of them — including a negative picture stride.
         let last = first + (rows as isize - 1) * pic_stride;
@@ -175,7 +186,8 @@ impl<BD: BitDepth> LfBand<BD> {
             return None;
         }
         Some(LfBandView {
-            stride: self.stride as isize,
+            stride: self.stride,
+            rows: self.rows,
             buf: &mut self.buf[..self.rows * self.stride],
         })
     }
@@ -185,6 +197,22 @@ impl<BD: BitDepth> LfBand<BD> {
 pub(crate) struct LfBandView<'c, BD: BitDepth> {
     pub(crate) buf: &'c mut [BD::Pixel],
     /// Row stride in pixels — also the band's column count.
-    pub(crate) stride: isize,
+    pub(crate) stride: usize,
+    pub(crate) rows: usize,
+}
+
+/// One `loop_filter_sb128` call's window on a band.
+///
+/// The anchor is carried as `(row, col)` rather than a flat offset on purpose:
+/// the V pass's rectangle grows along a row, and a flat
+/// `offset + len <= buf.len()` bound cannot tell a column overrun (which would
+/// silently read the NEXT band row) from a row overrun. Two axis bounds can.
+pub(crate) struct LfBandCursor<'c, BD: BitDepth> {
+    pub(crate) buf: &'c mut [BD::Pixel],
+    /// Band row/column of the pixel the picture call names as `dst`.
+    pub(crate) row: usize,
+    pub(crate) col: usize,
+    pub(crate) stride: usize,
+    pub(crate) rows: usize,
 }
 

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -5,6 +5,7 @@ use crate::include::common::bitdepth::DynPixel;
 use crate::include::common::intops::iclip;
 use crate::include::dav1d::picture::PicOffset;
 use crate::src::align::Align16;
+use crate::src::lf_band::LfBandCursor;
 use crate::src::cpu::CpuFlags;
 use crate::src::ffi_safe::FFISafe;
 use crate::src::internal::Rav1dFrameData;
@@ -57,7 +58,7 @@ fn loopfilter_sb_scalar<BD: BitDepth>(
     bd: BD,
     is_y: bool,
     is_v: bool,
-    band: Option<(&mut [BD::Pixel], usize, isize)>,
+    band: Option<LfBandCursor<BD>>,
 ) {
     match (is_y, is_v) {
         (true, false) => loop_filter_sb128_rust::<BD, { HV::H as usize }, { YUV::Y as usize }>(
@@ -84,7 +85,7 @@ fn loopfilter_sb_direct<BD: BitDepth>(
     w: usize,
     is_y: bool,
     is_v: bool,
-    band: Option<(&mut [BD::Pixel], usize, isize)>,
+    band: Option<LfBandCursor<BD>>,
 ) {
     let stride = dst.stride();
     let b4_stride = f.b4_stride;
@@ -208,7 +209,7 @@ impl loopfilter_sb::Fn {
         w: usize,
         is_y: bool,
         is_v: bool,
-        band: Option<(&mut [BD::Pixel], usize, isize)>,
+        band: Option<LfBandCursor<BD>>,
     ) {
         cfg_if::cfg_if! {
             if #[cfg(asm_loopfilter)] {
@@ -825,15 +826,10 @@ impl<'a, 'b, BD: BitDepth> LfBlock<'a, 'b, BD> {
     /// [`Self::open`] reading from an [`LfBand`](crate::src::lf_band::LfBand)
     /// instead of the picture — **zero borrow registrations**.
     ///
-    /// `H` only (`is_v == false`): the V pass's rectangle grows along a picture
-    /// row, so fusing already divides its guard count and a band buys it
-    /// nothing (measured: 1.000x for H, 1.971x for V — see
-    /// [`crate::src::lf_band`]).
-    ///
-    /// `band_off` is the band offset of the same pixel `dst` names in the
-    /// picture, and `band_stride` the band's row stride. The rectangle is the
-    /// SAME shape as [`Self::open`] would take — [`lf_geom`] is shared — so the
-    /// two paths differ only in where the bytes are read from.
+    /// The cursor names, in band coordinates, the same pixel `dst` names in
+    /// the picture. The rectangle is the SAME shape [`Self::open`] would take
+    /// — [`lf_geom`] is shared — so the two paths differ only in where the
+    /// bytes are read from.
     ///
     /// `origin`/`stride` are still the PICTURE's, because
     /// [`Self::close_band`] writes the changed span to the picture exactly as
@@ -843,9 +839,8 @@ impl<'a, 'b, BD: BitDepth> LfBlock<'a, 'b, BD> {
     #[inline]
     fn open_band(
         scratch: &'b mut LfScratch<BD>,
-        band: &[BD::Pixel],
-        band_off: usize,
-        band_stride: isize,
+        band: &LfBandCursor<BD>,
+        is_v: bool,
         dst: PicOffset<'a>,
         stride: isize,
         wd: c_int,
@@ -858,19 +853,26 @@ impl<'a, 'b, BD: BitDepth> LfBlock<'a, 'b, BD> {
             stridea,
             strideb,
             base,
-        } = lf_geom(false, reach, groups);
+        } = lf_geom(is_v, reach, groups);
 
-        // The band rectangle. Both ends are checked, so every row between them
-        // is in range for a stride of either sign.
-        let b_first = (band_off as isize).checked_sub(reach)?;
-        let b_last = b_first + (h as isize - 1) * band_stride;
-        if b_first.min(b_last) < 0 || b_first.max(b_last) + w as isize > band.len() as isize {
+        // The band rectangle, bounded on BOTH axes. `V` grows along a row and
+        // `H` down a column, so a flat `offset + len <= buf.len()` test would
+        // let a column overrun read the next band row instead of failing.
+        let (r0, c0) = if is_v {
+            (band.row.checked_sub(reach as usize)?, band.col)
+        } else {
+            (band.row, band.col.checked_sub(reach as usize)?)
+        };
+        if r0 + h > band.rows || c0 + w > band.stride {
             return None;
         }
+        let b_first = r0 * band.stride + c0;
+        let band_stride = band.stride as isize;
         // The PICTURE rectangle, checked exactly as `open` checks it — the
         // write-back in `close_band` goes there and must be in bounds even
         // though the read did not touch it.
-        let first = dst.offset as isize - reach;
+        let origin_delta = if is_v { -reach * stride } else { -reach };
+        let first = dst.offset as isize + origin_delta;
         let last = first + (h as isize - 1) * stride;
         if first < 0 || last < 0 {
             return None;
@@ -879,7 +881,7 @@ impl<'a, 'b, BD: BitDepth> LfBlock<'a, 'b, BD> {
             return None;
         }
 
-        let b_first = b_first as usize;
+        let band = &*band.buf;
         match w {
             4 => Self::fill_band::<4>(scratch, band, b_first, band_stride, h),
             6 => Self::fill_band::<6>(scratch, band, b_first, band_stride, h),
@@ -908,7 +910,7 @@ impl<'a, 'b, BD: BitDepth> LfBlock<'a, 'b, BD> {
             base,
             stridea,
             strideb,
-            is_v: false,
+            is_v,
         })
     }
 
@@ -945,7 +947,17 @@ impl<'a, 'b, BD: BitDepth> LfBlock<'a, 'b, BD> {
     /// superblock (whose window overlaps this one) reads what this call wrote,
     /// and so that a later `open_band` returning `None` can fall back to the
     /// picture and see the same bytes.
-    fn close_band(self, band: &mut [BD::Pixel], band_first: usize, band_stride: isize) {
+    fn close_band(self, band: &mut LfBandCursor<BD>) {
+        // The rectangle's origin is derived from the SAME cursor and the SAME
+        // `lf_geom` shape `open_band` used (`reach` is `h / 2` for `V` and
+        // `w / 2` for `H`), so the two cannot drift apart.
+        let band_stride = band.stride as isize;
+        let band_first = if self.is_v {
+            (band.row - self.h / 2) * band.stride + band.col
+        } else {
+            band.row * band.stride + band.col - self.w / 2
+        };
+        let band = &mut *band.buf;
         for row in 0..self.h {
             let Some((first, last)) = self.changed_span(row) else {
                 continue; // row untouched: no write, no mutable guard
@@ -1396,10 +1408,10 @@ fn loop_filter_sb128_rust<BD: BitDepth, const HV: usize, const YUV: usize>(
     lut: &Align16<Av1FilterLUT>,
     _wh: c_int,
     bd: BD,
-    // `(band buffer, band offset of `dst`, band row stride)`. `H` only; the
-    // caller passes `None` for `V` and for every asm build. See
+    // A read cache for the rectangle this call filters, anchored at `dst`.
+    // `None` for every asm build and whenever the band declined to fill. See
     // [`crate::src::lf_band`].
-    mut band: Option<(&mut [BD::Pixel], usize, isize)>,
+    mut band: Option<LfBandCursor<BD>>,
 ) {
     let hv = HV::from_repr(HV).unwrap();
     let yuv = YUV::from_repr(YUV).unwrap();
@@ -1419,12 +1431,6 @@ fn loop_filter_sb128_rust<BD: BitDepth, const HV: usize, const YUV: usize>(
         YUV::UV => vmask[0] | vmask[1],
     };
     let is_v = matches!(hv, HV::V);
-    // The band's geometry is the H rectangle's; `lf_geom(true, ..)` grows the
-    // other way and `open_band` hardcodes `is_v == false`. Callers only ever
-    // arm it on the column pass, and this makes that a checked fact.
-    if is_v {
-        band = None;
-    }
 
     // Resolve every 4-pixel group's filter parameters before touching a pixel,
     // so consecutive groups that actually filter can be fused into one
@@ -1501,14 +1507,22 @@ fn loop_filter_sb128_rust<BD: BitDepth, const HV: usize, const YUV: usize>(
         // or a band too small for the run — falls straight through to the
         // picture path below, which reads identical bytes.
         let mut banded = false;
-        if let Some((buf, boff, bstride)) = band.as_mut() {
-            let bstride = *bstride;
-            let bg = boff.wrapping_add_signed(4 * bstride * g as isize);
+        if let Some(b) = band.as_mut() {
+            // Groups advance DOWN the band for `H` and ALONG a band row for
+            // `V` — the same axis `group_step = 4 * stridea` advances in the
+            // picture.
+            let mut cur = LfBandCursor {
+                buf: &mut *b.buf,
+                row: if is_v { b.row } else { b.row + 4 * g },
+                col: if is_v { b.col + 4 * g } else { b.col },
+                stride: b.stride,
+                rows: b.rows,
+            };
             if let Some(mut block) =
-                LfBlock::<BD>::open_band(&mut scratch, buf, bg, bstride, run_dst, stride, wd, n)
+                LfBlock::<BD>::open_band(&mut scratch, &cur, is_v, run_dst, stride, wd, n)
             {
                 block.filter_run(&params[g..g + n], wd, bd);
-                block.close_band(buf, bg.wrapping_add_signed(-lf_reach(wd)), bstride);
+                block.close_band(&mut cur);
                 banded = true;
             }
         }

--- a/src/loopfilter.rs
+++ b/src/loopfilter.rs
@@ -57,19 +57,20 @@ fn loopfilter_sb_scalar<BD: BitDepth>(
     bd: BD,
     is_y: bool,
     is_v: bool,
+    band: Option<(&mut [BD::Pixel], usize, isize)>,
 ) {
     match (is_y, is_v) {
         (true, false) => loop_filter_sb128_rust::<BD, { HV::H as usize }, { YUV::Y as usize }>(
-            dst, mask, lvl, b4_stride, lut, wh, bd,
+            dst, mask, lvl, b4_stride, lut, wh, bd, band,
         ),
         (true, true) => loop_filter_sb128_rust::<BD, { HV::V as usize }, { YUV::Y as usize }>(
-            dst, mask, lvl, b4_stride, lut, wh, bd,
+            dst, mask, lvl, b4_stride, lut, wh, bd, band,
         ),
         (false, false) => loop_filter_sb128_rust::<BD, { HV::H as usize }, { YUV::UV as usize }>(
-            dst, mask, lvl, b4_stride, lut, wh, bd,
+            dst, mask, lvl, b4_stride, lut, wh, bd, band,
         ),
         (false, true) => loop_filter_sb128_rust::<BD, { HV::V as usize }, { YUV::UV as usize }>(
-            dst, mask, lvl, b4_stride, lut, wh, bd,
+            dst, mask, lvl, b4_stride, lut, wh, bd, band,
         ),
     }
 }
@@ -83,6 +84,7 @@ fn loopfilter_sb_direct<BD: BitDepth>(
     w: usize,
     is_y: bool,
     is_v: bool,
+    band: Option<(&mut [BD::Pixel], usize, isize)>,
 ) {
     let stride = dst.stride();
     let b4_stride = f.b4_stride;
@@ -143,7 +145,7 @@ fn loopfilter_sb_direct<BD: BitDepth>(
 
             // Run scalar on restored state
             let bd = BD::from_c(bd_max);
-            loopfilter_sb_scalar::<BD>(dst, mask, lvl, b4_stride as usize, lut, wh, bd, is_y, is_v);
+            loopfilter_sb_scalar::<BD>(dst, mask, lvl, b4_stride as usize, lut, wh, bd, is_y, is_v, None);
 
             // Compare SIMD vs scalar
             let (guard, _) = dst.full_guard::<BD>();
@@ -191,7 +193,7 @@ fn loopfilter_sb_direct<BD: BitDepth>(
     {
         let b4_stride = b4_stride as usize;
         let bd = BD::from_c(bd_max);
-        loopfilter_sb_scalar::<BD>(dst, mask, lvl, b4_stride, lut, wh, bd, is_y, is_v);
+        loopfilter_sb_scalar::<BD>(dst, mask, lvl, b4_stride, lut, wh, bd, is_y, is_v, band);
     }
 }
 
@@ -206,10 +208,13 @@ impl loopfilter_sb::Fn {
         w: usize,
         is_y: bool,
         is_v: bool,
+        band: Option<(&mut [BD::Pixel], usize, isize)>,
     ) {
         cfg_if::cfg_if! {
             if #[cfg(asm_loopfilter)] {
-                let _ = (is_y, is_v);
+                // The band is a pure read cache and the asm kernel reads the
+                // picture; dropping it is correct, just unaccelerated.
+                let _ = (is_y, is_v, band);
                 let dst_ptr = dst.as_mut_ptr::<BD>().cast();
                 let stride = dst.stride();
                 assert!(lvl.offset <= lvl.data.len());
@@ -231,7 +236,7 @@ impl loopfilter_sb::Fn {
                 }
             } else {
                 // Direct dispatch: no function pointers, no extern "C" ABI overhead
-                loopfilter_sb_direct::<BD>(f, dst, mask, lvl, w, is_y, is_v)
+                loopfilter_sb_direct::<BD>(f, dst, mask, lvl, w, is_y, is_v, band)
             }
         }
     }
@@ -331,7 +336,7 @@ impl<BD: BitDepth> LfTaps<BD> for CompactTaps<'_, BD> {
 }
 
 /// Widest tap window any `wd` reads: `p6` at `-7` through `q6` at `+6`.
-const LF_TAP_REACH: isize = 7;
+pub(crate) const LF_TAP_REACH: isize = 7;
 
 /// Widest `2 * reach x 4` (or `4 x 2 * reach`) tap block.
 const LF_BLOCK_MAX: usize = 4 * 2 * LF_TAP_REACH as usize;
@@ -530,6 +535,119 @@ fn lf_double_reads() -> bool {
     false
 }
 
+/// Attribution counters for [`LfBlock::fill`]'s population — counts only.
+///
+/// The census in `docs/MUT_RECON_KERNELS.md` §11a gives this site ONE number
+/// (3,835,042/frame at t=8). That number cannot say which of the two passes
+/// produces it, and the two have completely different shapes: the H pass
+/// (`filter_plane_cols_*`, vertical edges) reads `4 * groups` rows of
+/// `2 * reach` pixels, so its cost is `4` registrations per filtering group no
+/// matter how the run fuses; the V pass (`filter_plane_rows_*`, horizontal
+/// edges) reads `2 * reach` rows of `4 * groups` pixels, so fusing `n` groups
+/// divides its cost by `n` and [`LF_BATCH_MAX`] caps `n` at 4.
+///
+/// A fix aimed at the wrong half buys nothing, so this measures the split
+/// first. Registrations, opens and runs are counted separately because
+/// "registrations per open" is what the two shapes disagree about.
+#[cfg(feature = "__probe_lf_hist")]
+pub mod lf_hist {
+    use core::sync::atomic::{AtomicU64, Ordering::Relaxed};
+
+    /// `[H, V]` — indexed by `is_v as usize`.
+    pub(super) static REGS: [AtomicU64; 2] = [AtomicU64::new(0), AtomicU64::new(0)];
+    pub(super) static OPENS: [AtomicU64; 2] = [AtomicU64::new(0), AtomicU64::new(0)];
+    /// Fused run length, 1..=4, per direction: `[dir][n - 1]`.
+    pub(super) static RUNLEN: [[AtomicU64; 4]; 2] = [
+        [
+            AtomicU64::new(0),
+            AtomicU64::new(0),
+            AtomicU64::new(0),
+            AtomicU64::new(0),
+        ],
+        [
+            AtomicU64::new(0),
+            AtomicU64::new(0),
+            AtomicU64::new(0),
+            AtomicU64::new(0),
+        ],
+    ];
+
+    /// Natural (UNCAPPED) run length, bucketed 1..=32, per direction.
+    /// `LF_BATCH_MAX` chops runs at 4; this is how long they would have been.
+    pub(super) static NATRUN: [[AtomicU64; 33]; 2] = [
+        [const { AtomicU64::new(0) }; 33],
+        [const { AtomicU64::new(0) }; 33],
+    ];
+    /// Registrations the V pass would take if the cap were lifted to 32:
+    /// one `2 * reach` open per NATURAL run instead of per capped run.
+    pub(super) static UNCAPPED_REGS: [AtomicU64; 2] =
+        [const { AtomicU64::new(0) }; 2];
+
+    #[inline]
+    pub(super) fn note(is_v: bool, h: usize, n: usize) {
+        let d = is_v as usize;
+        REGS[d].fetch_add(h as u64, Relaxed);
+        OPENS[d].fetch_add(1, Relaxed);
+        RUNLEN[d][(n - 1).min(3)].fetch_add(1, Relaxed);
+    }
+
+    /// Called once per NATURAL run (before the cap splits it).
+    ///
+    /// `h_one` is the row count ONE capped open of this run takes. For V that
+    /// is `2 * reach` and is independent of the run length, so an uncapped run
+    /// costs `h_one` total instead of `ceil(nat/4) * h_one` — that ratio is
+    /// the whole V-side prize. For H, `h = 4 * n` scales with the run, so an
+    /// uncapped run costs `4 * nat` either way and the prize is zero; the
+    /// counter records both so the asymmetry is measured, not assumed.
+    #[inline]
+    pub(super) fn note_natural(is_v: bool, nat: usize, h_one: usize) {
+        let d = is_v as usize;
+        NATRUN[d][nat.min(32)].fetch_add(1, Relaxed);
+        UNCAPPED_REGS[d].fetch_add(if is_v { h_one as u64 } else { (4 * nat) as u64 }, Relaxed);
+    }
+
+    /// One `LFHIST` row per direction, plus a run-length histogram.
+    pub fn report(iters: usize) -> String {
+        let mut s = String::new();
+        let it = iters.max(1) as f64;
+        for (d, name) in ["H_cols_vert_edges", "V_rows_horz_edges"].iter().enumerate() {
+            let regs = REGS[d].load(Relaxed) as f64 / it;
+            let opens = OPENS[d].load(Relaxed) as f64 / it;
+            let per = if opens > 0.0 { regs / opens } else { 0.0 };
+            s.push_str(&format!(
+                "LFHIST\t{name}\tregs_per_frame={regs:.0}\topens_per_frame={opens:.0}\tregs_per_open={per:.2}\n"
+            ));
+            for n in 0..4 {
+                s.push_str(&format!(
+                    "LFRUN\t{name}\tn={}\topens_per_frame={:.0}\n",
+                    n + 1,
+                    RUNLEN[d][n].load(Relaxed) as f64 / it
+                ));
+            }
+            let unc = UNCAPPED_REGS[d].load(Relaxed) as f64 / it;
+            s.push_str(&format!(
+                "LFUNCAP\t{name}\tregs_if_cap_32={unc:.0}\tvs_now={regs:.0}\tratio={:.3}\n",
+                if unc > 0.0 { regs / unc } else { 0.0 }
+            ));
+            let mut nat_sum = 0f64;
+            let mut nat_n = 0f64;
+            for n in 1..=32 {
+                let c = NATRUN[d][n].load(Relaxed) as f64 / it;
+                if c > 0.0 {
+                    s.push_str(&format!("LFNAT\t{name}\tnat={n}\truns_per_frame={c:.0}\n"));
+                    nat_sum += c * n as f64;
+                    nat_n += c;
+                }
+            }
+            s.push_str(&format!(
+                "LFNATAVG\t{name}\truns_per_frame={nat_n:.0}\tmean_natural_run={:.2}\n",
+                if nat_n > 0.0 { nat_sum / nat_n } else { 0.0 }
+            ));
+        }
+        s
+    }
+}
+
 struct LfBlock<'a, 'b, BD: BitDepth> {
     scratch: &'b mut LfScratch<BD>,
     /// Top-left of the rectangle in picture coordinates.
@@ -569,6 +687,44 @@ fn lf_reach(wd: c_int) -> isize {
     }
 }
 
+/// Shape of the rectangle one [`LfBlock`] covers, in pixels and scratch units.
+///
+/// Factored out so [`LfBlock::open`] and [`LfBlock::open_band`] cannot drift:
+/// the band path is a different SOURCE for the same rectangle, never a
+/// different rectangle. The origin delta is the one part that differs, because
+/// `V` shifts by rows (`-reach * stride`) and `H` by columns (`-reach`), and
+/// the two callers hold different strides.
+struct LfGeom {
+    w: usize,
+    h: usize,
+    stridea: isize,
+    strideb: isize,
+    base: usize,
+}
+
+#[inline(always)]
+fn lf_geom(is_v: bool, reach: isize, groups: usize) -> LfGeom {
+    if is_v {
+        // Taps run down the picture; each group's four columns run along x.
+        LfGeom {
+            w: 4 * groups,
+            h: 2 * reach as usize,
+            stridea: 1,
+            strideb: LF_BW as isize,
+            base: reach as usize * LF_BW,
+        }
+    } else {
+        // Taps run along x; each group's four columns run down the picture.
+        LfGeom {
+            w: 2 * reach as usize,
+            h: 4 * groups,
+            stridea: LF_BW as isize,
+            strideb: 1,
+            base: reach as usize,
+        }
+    }
+}
+
 impl<'a, 'b, BD: BitDepth> LfBlock<'a, 'b, BD> {
     /// Open the rectangle covering `groups` CONSECUTIVE 4-pixel groups that
     /// all filter with the same `wd`.
@@ -594,30 +750,17 @@ impl<'a, 'b, BD: BitDepth> LfBlock<'a, 'b, BD> {
         groups: usize,
     ) -> Option<Self> {
         let reach = lf_reach(wd);
+        let LfGeom {
+            w,
+            h,
+            stridea,
+            strideb,
+            base,
+        } = lf_geom(is_v, reach, groups);
         // `w`/`h` are the PICTURE rectangle — what gets guarded and written
         // back. The scratch row stride is `LF_BW` regardless, so `w` may be
         // narrower than a scratch row; see [`LF_BW`].
-        let (w, h, origin_delta, stridea, strideb, base) = if is_v {
-            // Taps run down the picture; each group's four columns run along x.
-            (
-                4 * groups,
-                2 * reach as usize,
-                -reach * stride,
-                1isize,
-                LF_BW as isize,
-                reach as usize * LF_BW,
-            )
-        } else {
-            // Taps run along x; each group's four columns run down the picture.
-            (
-                2 * reach as usize,
-                4 * groups,
-                -reach,
-                LF_BW as isize,
-                1isize,
-                reach as usize,
-            )
-        };
+        let origin_delta = if is_v { -reach * stride } else { -reach };
         let first = dst.offset as isize + origin_delta;
         let last = first + (h as isize - 1) * stride;
         if first < 0 || last < 0 {
@@ -630,6 +773,17 @@ impl<'a, 'b, BD: BitDepth> LfBlock<'a, 'b, BD> {
             data: dst.data,
             offset: first as usize,
         };
+        #[cfg(feature = "__probe_lf_hist")]
+        lf_hist::note(
+            is_v,
+            // What `fill` will actually register: the hull path is one.
+            if crate::include::dav1d::picture::tile_threading_active() {
+                h
+            } else {
+                1
+            },
+            groups,
+        );
         // `w` is one of six values, so the row copy is monomorphized on it:
         // `copy_from_slice` at a RUNTIME length is a `memmove` CALL per row,
         // and at up to 16 rows per open that call overhead measured as ~1.5%
@@ -666,6 +820,154 @@ impl<'a, 'b, BD: BitDepth> LfBlock<'a, 'b, BD> {
             strideb,
             is_v,
         })
+    }
+
+    /// [`Self::open`] reading from an [`LfBand`](crate::src::lf_band::LfBand)
+    /// instead of the picture — **zero borrow registrations**.
+    ///
+    /// `H` only (`is_v == false`): the V pass's rectangle grows along a picture
+    /// row, so fusing already divides its guard count and a band buys it
+    /// nothing (measured: 1.000x for H, 1.971x for V — see
+    /// [`crate::src::lf_band`]).
+    ///
+    /// `band_off` is the band offset of the same pixel `dst` names in the
+    /// picture, and `band_stride` the band's row stride. The rectangle is the
+    /// SAME shape as [`Self::open`] would take — [`lf_geom`] is shared — so the
+    /// two paths differ only in where the bytes are read from.
+    ///
+    /// `origin`/`stride` are still the PICTURE's, because
+    /// [`Self::close_band`] writes the changed span to the picture exactly as
+    /// [`Self::close`] does. Returns `None` on the same conditions
+    /// [`Self::open`] does, plus the band being too small; the caller then
+    /// takes the picture path, which reads identical bytes.
+    #[inline]
+    fn open_band(
+        scratch: &'b mut LfScratch<BD>,
+        band: &[BD::Pixel],
+        band_off: usize,
+        band_stride: isize,
+        dst: PicOffset<'a>,
+        stride: isize,
+        wd: c_int,
+        groups: usize,
+    ) -> Option<Self> {
+        let reach = lf_reach(wd);
+        let LfGeom {
+            w,
+            h,
+            stridea,
+            strideb,
+            base,
+        } = lf_geom(false, reach, groups);
+
+        // The band rectangle. Both ends are checked, so every row between them
+        // is in range for a stride of either sign.
+        let b_first = (band_off as isize).checked_sub(reach)?;
+        let b_last = b_first + (h as isize - 1) * band_stride;
+        if b_first.min(b_last) < 0 || b_first.max(b_last) + w as isize > band.len() as isize {
+            return None;
+        }
+        // The PICTURE rectangle, checked exactly as `open` checks it — the
+        // write-back in `close_band` goes there and must be in bounds even
+        // though the read did not touch it.
+        let first = dst.offset as isize - reach;
+        let last = first + (h as isize - 1) * stride;
+        if first < 0 || last < 0 {
+            return None;
+        }
+        if first.max(last) as usize + w > dst.data.pixel_len::<BD>() {
+            return None;
+        }
+
+        let b_first = b_first as usize;
+        match w {
+            4 => Self::fill_band::<4>(scratch, band, b_first, band_stride, h),
+            6 => Self::fill_band::<6>(scratch, band, b_first, band_stride, h),
+            8 => Self::fill_band::<8>(scratch, band, b_first, band_stride, h),
+            12 => Self::fill_band::<12>(scratch, band, b_first, band_stride, h),
+            14 => Self::fill_band::<14>(scratch, band, b_first, band_stride, h),
+            16 => Self::fill_band::<16>(scratch, band, b_first, band_stride, h),
+            _ => {
+                for row in 0..h {
+                    let off = b_first.wrapping_add_signed(row as isize * band_stride);
+                    let src = &band[off..][..w];
+                    scratch.buf[row * LF_BW..][..w].copy_from_slice(src);
+                    scratch.pristine[row * LF_BW..][..w].copy_from_slice(src);
+                }
+            }
+        }
+        Some(Self {
+            scratch,
+            origin: PicOffset {
+                data: dst.data,
+                offset: first as usize,
+            },
+            stride,
+            w,
+            h,
+            base,
+            stridea,
+            strideb,
+            is_v: false,
+        })
+    }
+
+    /// [`Self::fill`] from a plain slice. No guard, no tracker, no policy
+    /// branch — the band is an ordinary `&[BD::Pixel]` the caller owns.
+    #[inline(always)]
+    fn fill_band<const W: usize>(
+        scratch: &mut LfScratch<BD>,
+        band: &[BD::Pixel],
+        first: usize,
+        stride: isize,
+        h: usize,
+    ) {
+        for row in 0..h {
+            let off = first.wrapping_add_signed(row as isize * stride);
+            let src: &[BD::Pixel; W] = (&band[off..][..W]).try_into().expect("band row is W long");
+            let dst: &mut [BD::Pixel; W] = (&mut scratch.buf[row * LF_BW..][..W])
+                .try_into()
+                .expect("scratch row is LF_BW >= W long");
+            *dst = *src;
+            let pri: &mut [BD::Pixel; W] = (&mut scratch.pristine[row * LF_BW..][..W])
+                .try_into()
+                .expect("scratch row is LF_BW >= W long");
+            *pri = *src;
+        }
+    }
+
+    /// [`Self::close`], plus a mirror of the same span into the band.
+    ///
+    /// **The picture write is byte-for-byte what [`Self::close`] does** — same
+    /// `changed_span`, same one mutable guard per changed row, same extent. The
+    /// band is not an owner and never becomes authoritative; mirroring is only
+    /// what keeps it equal to the picture, so that the next `x` in this
+    /// superblock (whose window overlaps this one) reads what this call wrote,
+    /// and so that a later `open_band` returning `None` can fall back to the
+    /// picture and see the same bytes.
+    fn close_band(self, band: &mut [BD::Pixel], band_first: usize, band_stride: isize) {
+        for row in 0..self.h {
+            let Some((first, last)) = self.changed_span(row) else {
+                continue; // row untouched: no write, no mutable guard
+            };
+            let work = &self.scratch.buf[row * LF_BW..][..self.w];
+            let changed = &work[first..=last];
+
+            let boff = band_first.wrapping_add_signed(row as isize * band_stride) + first;
+            band[boff..][..changed.len()].copy_from_slice(changed);
+
+            let off = self
+                .origin
+                .offset
+                .wrapping_add_signed(row as isize * self.stride)
+                + first;
+            let mut guard = PicOffset {
+                data: self.origin.data,
+                offset: off,
+            }
+            .slice_mut::<BD>(last + 1 - first);
+            guard.copy_from_slice(changed);
+        }
     }
 
     /// Read `h` picture rows of exactly `W` pixels into the scratch and its
@@ -1094,6 +1396,10 @@ fn loop_filter_sb128_rust<BD: BitDepth, const HV: usize, const YUV: usize>(
     lut: &Align16<Av1FilterLUT>,
     _wh: c_int,
     bd: BD,
+    // `(band buffer, band offset of `dst`, band row stride)`. `H` only; the
+    // caller passes `None` for `V` and for every asm build. See
+    // [`crate::src::lf_band`].
+    mut band: Option<(&mut [BD::Pixel], usize, isize)>,
 ) {
     let hv = HV::from_repr(HV).unwrap();
     let yuv = YUV::from_repr(YUV).unwrap();
@@ -1113,6 +1419,12 @@ fn loop_filter_sb128_rust<BD: BitDepth, const HV: usize, const YUV: usize>(
         YUV::UV => vmask[0] | vmask[1],
     };
     let is_v = matches!(hv, HV::V);
+    // The band's geometry is the H rectangle's; `lf_geom(true, ..)` grows the
+    // other way and `open_band` hardcodes `is_v == false`. Callers only ever
+    // arm it on the column pass, and this makes that a checked fact.
+    if is_v {
+        band = None;
+    }
 
     // Resolve every 4-pixel group's filter parameters before touching a pixel,
     // so consecutive groups that actually filter can be fused into one
@@ -1173,7 +1485,37 @@ fn loop_filter_sb128_rust<BD: BitDepth, const HV: usize, const YUV: usize>(
         while n < LF_BATCH_MAX && g + n < n_groups && filters[g + n] && params[g + n].3 == wd {
             n += 1;
         }
+        // Count each NATURAL run once, at its first group — `g` re-enters this
+        // loop mid-run whenever the cap split one.
+        #[cfg(feature = "__probe_lf_hist")]
+        if g == 0 || !filters[g - 1] || params[g - 1].3 != wd {
+            let mut nat = 1;
+            while g + nat < n_groups && filters[g + nat] && params[g + nat].3 == wd {
+                nat += 1;
+            }
+            lf_hist::note_natural(is_v, nat, 2 * lf_reach(wd) as usize);
+        }
         let run_dst = dst + group_step * g as isize;
+        // The band, when one is armed, is a read cache for THIS rectangle;
+        // `close_band` still writes the picture. `None` here — off the plane,
+        // or a band too small for the run — falls straight through to the
+        // picture path below, which reads identical bytes.
+        let mut banded = false;
+        if let Some((buf, boff, bstride)) = band.as_mut() {
+            let bstride = *bstride;
+            let bg = boff.wrapping_add_signed(4 * bstride * g as isize);
+            if let Some(mut block) =
+                LfBlock::<BD>::open_band(&mut scratch, buf, bg, bstride, run_dst, stride, wd, n)
+            {
+                block.filter_run(&params[g..g + n], wd, bd);
+                block.close_band(buf, bg.wrapping_add_signed(-lf_reach(wd)), bstride);
+                banded = true;
+            }
+        }
+        if banded {
+            g += n;
+            continue;
+        }
         match LfBlock::<BD>::open(&mut scratch, run_dst, is_v, stride, wd, n) {
             Some(mut block) => {
                 block.filter_run(&params[g..g + n], wd, bd);
@@ -1239,7 +1581,7 @@ unsafe extern "C" fn loop_filter_sb128_c_erased<BD: BitDepth, const HV: usize, c
     let lvl = *unsafe { FFISafe::get(lvl) };
     let b4_stride = b4_stride as usize;
     let bd = BD::from_c(bitdepth_max);
-    loop_filter_sb128_rust::<BD, { HV }, { YUV }>(dst, vmask, lvl, b4_stride, lut, wh, bd)
+    loop_filter_sb128_rust::<BD, { HV }, { YUV }>(dst, vmask, lvl, b4_stride, lut, wh, bd, None)
 }
 
 impl Rav1dLoopFilterDSPContext {


### PR DESCRIPTION
Campaign #455. Takes on `LfBlock::fill` — the decoder's largest guard site, 3,835,042
registrations/frame at `v4k_8tile` 8bpc t=8, 33.6% of 11,401,399 — and lands **one
instrument, one measured negative, and no perf change**. The default build is
behaviourally `main`.

## Read this first: what is NOT here

* **No speedup ships.** The band that produced the 3.7% below is **default OFF** because
  it fails 1–64 corpus vectors per run at `--threads 8`, nondeterministically.
* **The V pass's cheap sound win is measured but NOT taken** (§16: cap 4→32 divides its
  registrations by 1.971). It is blocked on a rectangular scratch and on decoupling the
  NEON kernel batch from the guard batch; both untouched.
* **`cdef_arm` (1,863,648) and `ctx.rs:99` (2,534,988) untouched**, as in every prior round.
* Not measured: x86_64/wasm32 (compile-checked), `asm`/`c-ffi`, `unchecked`, t=16, any
  vector below 4K, any vector with loop restoration live.
* **The full wall-clock sweep never ran.** The box was held by another agent's `measlock`
  for the window it needed, and once the band was refuted there was nothing shippable left
  to sweep. The only timed number here is the paired user-CPU A/B.

## 1. Attribution (new instrument, `--features __probe_lf_hist`)

The census gives this site one number; it cannot say which pass produces it. Split, at t=8
(reconciles to 3,835,042 **to the registration** after the probe's warmup scale, which is
the instrument's control):

| pass | regs/frame | share | shape |
|---|---|---|---|
| H — `filter_plane_cols_*` | **2,656,552** | 69.3% | `4*groups` rows × `2*reach` px |
| V — `filter_plane_rows_*` | **1,178,490** | 30.7% | `2*reach` rows × `4*groups` px |

79% of opens hit the `LF_BATCH_MAX = 4` cap exactly. Pricing the obvious lever from the
same run — what each natural run *would* have cost uncapped:

| cap 4 → 32 | now | uncapped | ratio |
|---|---|---|---|
| V | 1,178,490 | 597,876 | **1.971** |
| H | 2,656,552 | 2,656,552 | **1.000** |

Exactly 1.000 for H, structurally: its rectangle grows in the ROW direction, so a run of
`n` groups costs `4n` guards however it splits. **69.3% of the site cannot be bought by
fusing along the run at all.**

## 2. The band, and its registration table

A per-superblock **read cache** (`src/lf_band.rs`): one contiguous immutable guard per
picture row, once per superblock, for all of that superblock's calls. It needs none of the
halo handshake §11b found inexpressible, because it never owns anything — `close_band`
writes the picture with the same mutable guard `close` always took, and mirrors into the
band, so the band never diverges and any call may fall back to the picture path.

`--features probe-sites`, `lost=0`, one binary:

| | band OFF | band ON |
|---|---|---|
| whole decoder, t=8 | 11,401,399 | **8,026,355** (−29.6%) |
| `LfBlock::fill` | 3,835,042 | 35,570 (−99.1%) |
| `LfBand::fill_from` | 0 | 424,428 @ **134 B** |
| writes | 17,852 | **17,852** (identical) |

## 3. Why it is default OFF — measured, and the first run lied

**The read set is 2-D SPARSE; every per-row band is contiguous.** The difference is
columns and rows reserved but never read, and another worker is legitimately writing them:

```
current:  &     _[163840..163968]   <- the band's 128-px row copy-in
existing: &mut  _[163944..163952]   <- a concurrent 8-px write inside it
```

Same defect class as §11c's hull, transposed: the hull reserved the gaps between rows,
this reserves the gaps between edges. `md5_inventory --threads 8`, group `8-bit/data`
(358 vectors), repeated on one box:

| arm | pass | error |
|---|---|---|
| base `0f6bf10`, its own binary | 358 ×3 | **0 ×3** |
| column band only | 357 / 356 / 358 | **1 / 2 / 0** |
| column + row band | 294 | **64** |
| default build (band off) | 358 ×4 | **0 ×4** |

The column-only band's **first** full t=8 corpus run passed 753/755 `SETDIFF: CLEAN`, and
it was committed on that. One sample. A rare false positive is a decode *failure*, not a
wrong pixel, so an md5 diff cannot see it — only an error count can.

`tile_threading_active()` does not rescue it: that latch gates concurrent **tile** workers,
while this concurrency is between **sbrow filter tasks** (`src/thread_task.rs:1030-1043`),
which exist whenever `n_tc > 1`. Gated that way the t=8 census is byte-identical to `main`
(the band provably never armed) and `8-bit/data` **still produced 8 errors in one run of two.**

## 4. The number the armed arm is still good for

Paired user CPU, `v4k_8tile` 8bpc t=8, 20 frames, one binary, rotating arm order, under
`measlock`, n=9, foreign_max=1 (load-tagged):

**band / band-off = 0.9628 median, [0.9523..0.9781], 9/9 faster.**

Not available — but it is the first *direct* price for removing ~2.4 M of this site's
registrations without paying extent, where §11f could only bound it from above by doubling.

## 5. Gates (default build)

* Census `lost=0`: **6,005,602** t=1, **11,401,399** t=8 — both exactly §11a's numbers.
* Corpus set-diffed BY NAME with the md5 as the value vs
  `benchmarks/aarch64_md5_fixes_2026-08-07_final.tsv.zst`: t=1 **766 PASS / 768 keys /
  0 differing, CLEAN**; t=8 with `8-bit/film_grain` + `10-bit/film_grain` dropped from
  BOTH sides (#479) **753 PASS / 755 keys / 0 differing, CLEAN**. `8-bit/data` at t=8
  clean 4 of 4.
* Frame md5 identical across band {on,off} × t {1,2,8} × {8,10}bpc: 12/12,
  `a00c11f454328023c58af14d55544cff` / `4f218411bc6ee4cc9c630fe827337fa2`.
* **Teeth proved:** an off-by-one planted in the band read fails **13/14** corpus tests;
  restored byte-exact (sha256 + `git diff --exit-code`), green again after `touch`.
  **Honest gap:** deleting the `close_band` mirror is NOT caught (14/14 still pass) — the
  mirror is kept as an invariant, not because a test can see it.
* `#![forbid(unsafe_code)]` proved ACTIVELY in `src/lf_band.rs` (unconditionally compiled):
  `error: usage of an 'unsafe' block`, lint anchored at **`lib.rs:13`**, not a module-local
  `cfg_attr`. Restored byte-exact (sha256 `6512f6ea…ede22`, `git diff --exit-code` clean).
* `crates/rav1d-disjoint-mut` byte-identical to base (`git diff 0f6bf10 -- crates/` empty;
  `tracker_shard.rs` = `d4e03d4a…423176d`, the value #482/#483 recorded).
* Clippy: both CI legs clean on aarch64 **and** x86_64. `--all-targets` x86 fails on base
  and head alike, in files this branch does not touch.

## 6. For the next attempt

* **Do not build another contiguous band.** Column-major, row-major and both are now
  measured. The obstruction is that the read set is sparse in 2-D and the tracker's unit is
  an interval.
* **Take the V cap lift** (1.971×, no extent change): blocked only on `LF_BW`'s
  `assert!(LF_BW * LF_BW == LF_BLOCK_LEN)` and `loopfilter_arm.rs:156`'s
  `LF_GROUPS == LF_BATCH_MAX`. Watch `LfScratch::new`'s zero-init — ~100 K calls/frame.
* **H needs a different mechanism, not a bigger batch** (cap-lift ratio exactly 1.000).
