### PR TITLE
docs: CORRECTION — two counts I published in the #489/#499 landings were not counted

### DIFF
--- a/docs/TILED_SCALING.md
+++ b/docs/TILED_SCALING.md
@@ -12,8 +12,12 @@ Provenance, arms, hygiene and the raw files: `benchmarks/tiled_scaling_2026-08-1
 > **Landed 2026-08-12 from PR #499, which was marked "measure-only, do not
 > merge".** The label was about the branch, not the record: its nine
 > `scripts/perf/tiled_*` tools reached `main` already (via #500, `54e90d8`) and
-> `docs/AGENT_BRIEF.md` §6 has cited **this file** by name in three separate rows
-> since — with the file itself absent from `main`. So the records land; nothing
+> `docs/AGENT_BRIEF.md` §6 has cited **this file** by name in **two** rows
+> since (*corrected 2026-08-12: the banner first said three, from memory rather
+> than a count —* `grep -o 'docs/TILED_SCALING\.md' docs/AGENT_BRIEF.md | wc -l`
+> *= 2, the dav1d-tiled-scheduler row and the filter-chain row. A third row, the
+> post-tile filter tail, states §4's finding but names only the* `TAIL_CONC`
+> *instrument.*) — with the file itself absent from `main`. So the records land; nothing
 > that made the branch un-mergeable comes with them (no `src/`, no `crates/`, no
 > `Cargo.toml`, and its `.gitignore` reversion of the `test-vectors` symlink line
 > is dropped — only the `__pycache__` addition is kept).


### PR DESCRIPTION
Self-correction on two numbers I asserted while landing the campaign records, both written from
recollection rather than from a count. Per the campaign's own rule (`docs/AGENT_BRIEF.md` §3), an
unsourced number gets corrected in place and labelled, not quietly reworded.

## 1. In the tree: `docs/TILED_SCALING.md`'s landing banner (from #512)

Said `docs/AGENT_BRIEF.md` §6 cites the file "in three separate rows". Counted:

```
$ grep -o 'docs/TILED_SCALING\.md' docs/AGENT_BRIEF.md | wc -l
2
```

The dav1d-tiled-scheduler row and the filter-chain row. A third §6 row — the post-tile filter tail —
states §4's finding but names only the `TAIL_CONC` instrument, not the file. Fixed here, with the
count and the command in the text.

The argument for landing the record is unaffected: two dangling references is the same defect as
three, and the file is on `main` now either way.

## 2. Not in the tree, corrected where it was published

PR **#510**'s body and its merged commit message say a mechanical rebase of #489's
`docs/AGENT_BRIEF.md` diff "would have silently reverted **eleven** §2 bullets and four §6 rows".
Counted from the diff:

```
$ git diff 675a7ff pr489 -- docs/AGENT_BRIEF.md | grep '^-- \*\*' | wc -l
7        # §2 bullets deleted outright
$ ... | grep '^-| ' | wc -l
4        # §6 table rows touched — but ONE of the four is a MODIFICATION
         # (the "Coarsening a guard extent" row is replaced, not removed),
         # so net-deleted §6 rows = 3
```

**Correct figure: 7 §2 bullets deleted outright, plus a 3-line parenthetical inside an eighth (the
`measlock` ownership note), plus 3 §6 rows net-deleted and 1 modified.** Not eleven. The substantive
point stands unchanged and is why the diff was applied by hand instead of mechanically: #489's base
predates `ca26fd6` ("adopt the fullest version — the workspace copy had diverged and was stale"), so
applying it as a diff would have reverted real content. Only the 60 B correction was carried across.

#510's body is edited and a correction comment is posted on #489. Its commit message is already on
`main` and cannot be; this PR is the durable record of that.

Docs only. No code, no measurement.