### PR TITLE
ci: give the MD5 conformance gate teeth, and add the t=8 leg it never had

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,18 +128,47 @@ jobs:
 
       # Download test vectors and run the full dav1d MD5 conformance. Runs on x86
       # AND native arm64 (safe-simd-arm64) — the comprehensive aarch64 regression
-      # guard (issue #414). `continue-on-error` because aarch64 is not yet fully
-      # conformant (mc_arm 8-tap OOB on inter frames); this tracks the state and
-      # surfaces progress/regressions until it can become a hard gate.
+      # guard (issue #414).
+      #
+      # 2026-08-11: BOTH `continue-on-error`s removed and a t=8 leg added. The
+      # old comment justified them with "aarch64 is not yet fully conformant
+      # (mc_arm 8-tap OOB on inter frames)" — that is stale. The corpus now
+      # passes 766/766 on aarch64 AND x86_64 at t=1, and 766/766 at t=8 on
+      # aarch64, with nothing skipped (#455 campaign; 302/766 at its start).
+      #
+      # Both flags together made this gate unable to report anything: a failed
+      # download fell through to a run with no vectors, which then also could
+      # not fail. And `Settings::default()` is `threads: 1`, so the only leg
+      # that ran had NO tile-threading coverage — which is precisely why the
+      # x86_64 t=8 deblock race (#494/#497) reached main. The t=8 leg below is
+      # the cheapest thing that would have caught it.
+      #
+      # The download is retried instead of ignored: a network flake should cost
+      # a retry, not silently disarm the conformance suite.
       - name: Download test vectors
         if: (matrix.label == 'safe-simd' || matrix.label == 'safe-simd-arm64') && runner.os == 'Linux'
-        run: bash scripts/download-test-vectors.sh
-        continue-on-error: true
+        run: |
+          for attempt in 1 2 3; do
+            if bash scripts/download-test-vectors.sh; then exit 0; fi
+            echo "download-test-vectors.sh failed (attempt $attempt/3); retrying in $((attempt * 10))s" >&2
+            sleep $((attempt * 10))
+          done
+          echo "download-test-vectors.sh failed after 3 attempts" >&2
+          exit 1
 
-      - name: Run MD5 decode parity tests
+      - name: Run MD5 decode parity tests (t=1)
         if: (matrix.label == 'safe-simd' || matrix.label == 'safe-simd-arm64') && runner.os == 'Linux'
         run: cargo nextest run --profile ci --no-default-features --features "${{ matrix.features }}" --release --test decode_md5_verify
-        continue-on-error: true
+
+      # Tile-threaded conformance. Same 766 vectors, same expected MD5s — a
+      # decode that changes with the worker count is a bug in the threading, and
+      # this is the gate that says so. `RAV1D_MD5_THREADS` is read by the test
+      # and defaults to 1, so the leg above is unaffected by its existence.
+      - name: Run MD5 decode parity tests (t=8, tile threading)
+        if: (matrix.label == 'safe-simd' || matrix.label == 'safe-simd-arm64') && runner.os == 'Linux'
+        env:
+          RAV1D_MD5_THREADS: 8
+        run: cargo nextest run --profile ci --no-default-features --features "${{ matrix.features }}" --release --test decode_md5_verify
 
   # ==========================================================================
   # Clippy lint check

--- a/scripts/download-test-vectors.sh
+++ b/scripts/download-test-vectors.sh
@@ -57,14 +57,51 @@ echo ""
 echo "Attempting to clone dav1d test data repository..."
 DAV1D_DATA_DIR="$VECTORS_DIR/dav1d-test-data"
 
-if [ ! -d "$DAV1D_DATA_DIR" ]; then
-    if git clone --depth 1 https://code.videolan.org/videolan/dav1d-test-data.git "$DAV1D_DATA_DIR" 2>/dev/null; then
-        echo "  ✓ dav1d test data cloned"
-    else
-        echo "  ⓘ dav1d test data not available (optional)"
-    fi
-else
+# The 766-vector conformance corpus. This is NOT optional: it is the only
+# thing that checks decode output against dav1d's reference MD5s.
+#
+# 2026-08-12: this block used to `2>/dev/null` the clone and, on failure, print
+# "not available (optional)" and exit 0. Combined with `continue-on-error` in
+# ci.yml, that meant a failed fetch produced a GREEN build with zero
+# conformance coverage — and it had been failing on Linux runners, so the
+# corpus gate had never actually run in CI. Three layers hid it: this
+# swallowed stderr, this exited 0, and the workflow ignored the result anyway.
+#
+# The sentinel is the same file the test harness checks
+# (tests/test_vectors.rs `ensure_dav1d_test_data`), so a partial clone that
+# leaves the directory non-empty but incomplete is caught here rather than
+# surfacing later as the harness's own `git clone` exiting 128 on a
+# non-empty destination.
+SENTINEL="$DAV1D_DATA_DIR/8-bit/data/meson.build"
+
+if [ -f "$SENTINEL" ]; then
     echo "  ✓ dav1d test data (cached)"
+else
+    if [ -d "$DAV1D_DATA_DIR" ]; then
+        echo "  ! $DAV1D_DATA_DIR exists but is incomplete (no $SENTINEL) — removing" >&2
+        rm -rf "$DAV1D_DATA_DIR"
+    fi
+    ok=0
+    for attempt in 1 2 3; do
+        # stderr is NOT discarded: the reason a fetch fails is the whole
+        # diagnostic, and discarding it is what made this invisible.
+        if git clone --depth 1 https://code.videolan.org/videolan/dav1d-test-data.git "$DAV1D_DATA_DIR"; then
+            ok=1
+            break
+        fi
+        echo "  ! clone attempt $attempt/3 failed" >&2
+        rm -rf "$DAV1D_DATA_DIR"
+        sleep $((attempt * 10))
+    done
+    if [ "$ok" != "1" ]; then
+        echo "  ✗ dav1d test data clone FAILED after 3 attempts" >&2
+        exit 1
+    fi
+    if [ ! -f "$SENTINEL" ]; then
+        echo "  ✗ clone reported success but $SENTINEL is missing" >&2
+        exit 1
+    fi
+    echo "  ✓ dav1d test data cloned"
 fi
 
 echo ""

--- a/scripts/download-test-vectors.sh
+++ b/scripts/download-test-vectors.sh
@@ -55,7 +55,14 @@ done
 # Try to download from dav1d test data repo
 echo ""
 echo "Attempting to clone dav1d test data repository..."
-DAV1D_DATA_DIR="$VECTORS_DIR/dav1d-test-data"
+# NOT under $VECTORS_DIR. The conformance harness resolves this corpus as
+# `$CARGO_MANIFEST_DIR/test-vectors/dav1d-test-data` (tests/test_vectors.rs),
+# while $VECTORS_DIR is `${CARGO_TARGET_DIR:-target}/test-vectors`. Those have
+# never been the same directory, so every clone this script made was invisible
+# to the tests, which then re-cloned for themselves. Populate the path the
+# harness actually reads.
+DAV1D_DATA_DIR="$PROJECT_ROOT/test-vectors/dav1d-test-data"
+mkdir -p "$PROJECT_ROOT/test-vectors"
 
 # The 766-vector conformance corpus. This is NOT optional: it is the only
 # thing that checks decode output against dav1d's reference MD5s.

--- a/tests/decode_md5_verify.rs
+++ b/tests/decode_md5_verify.rs
@@ -25,6 +25,35 @@ fn dav1d_test_data() -> PathBuf {
     test_vectors::ensure_dav1d_test_data()
 }
 
+/// Worker-thread count for the conformance decode, from `RAV1D_MD5_THREADS`.
+///
+/// Defaults to 1, which is what `Settings::default()` gives and therefore what
+/// this suite has always run — so an unset variable changes nothing.
+///
+/// It is an env var read HERE rather than a second `#[test]` because the
+/// decision belongs to the caller and must be visible in the chain
+/// (CI workflow -> justfile -> invocation), per the project's rule against
+/// skip/spread decisions buried in a test body. `ci.yml` runs the corpus twice,
+/// once unset and once at 8.
+///
+/// Why this exists: until 2026-08-11 the corpus leg ran ONLY at the default of
+/// 1, so CI had no tile-threading coverage of the decoder at all. The x86_64
+/// t=8 deblock read/write race (#494/#497) — a V-window using a constant
+/// `tap_after = 7` instead of the mask-selected reach, reading 3 rows past its
+/// superblock row — could not have been caught here, and was not.
+///
+/// A malformed value is a hard error, not a silent fallback: a typo in a CI
+/// file must not quietly downgrade the gate to the single-threaded run it is
+/// meant to complement.
+fn md5_threads() -> u32 {
+    match std::env::var("RAV1D_MD5_THREADS") {
+        Ok(s) => s
+            .parse()
+            .unwrap_or_else(|e| panic!("RAV1D_MD5_THREADS={s:?} is not a u32: {e}")),
+        Err(_) => 1,
+    }
+}
+
 /// A test vector with its expected MD5 hash.
 struct TestVector {
     name: String,
@@ -154,6 +183,7 @@ fn compute_decode_md5_with_grain(
 
     let mut settings = Settings::default();
     settings.apply_grain = apply_grain;
+    settings.threads = md5_threads();
     let mut decoder =
         Decoder::with_settings(settings).map_err(|e| format!("Failed to create decoder: {e}"))?;
     let mut ctx = md5::Context::new();

--- a/tests/test_vectors.rs
+++ b/tests/test_vectors.rs
@@ -24,22 +24,49 @@ pub fn ensure_dav1d_test_data() -> PathBuf {
         let parent = dir.parent().unwrap();
         std::fs::create_dir_all(parent).expect("failed to create test-vectors/");
 
+        // Clone to a PID-unique staging directory and rename into place.
+        //
+        // `DOWNLOAD: Once` only serialises within one process, and nextest runs
+        // every test in its OWN process — so all 13 conformance tests reached
+        // this clone concurrently. The first created `dir`; the other twelve
+        // hit `git clone`'s "destination path already exists" and died with
+        // exit 128. That is the failure CI reported, and it could not
+        // reproduce under `cargo test`, which is single-process and where the
+        // `Once` does work.
+        //
+        // Staging + rename makes the race benign: every process does its own
+        // clone, exactly one rename wins, and the losers see the sentinel and
+        // discard their copy. Wasteful under a cold cache, correct always —
+        // and in CI the fetch script populates this path first, so normally no
+        // process clones at all.
+        let staging = parent.join(format!("dav1d-test-data.staging.{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&staging);
+
         let status = std::process::Command::new("git")
             .args([
                 "clone",
                 "--depth",
                 "1",
                 "https://code.videolan.org/videolan/dav1d-test-data.git",
-                dir.to_str().unwrap(),
+                staging.to_str().unwrap(),
             ])
             .status()
             .expect("failed to run git — is git installed?");
 
         assert!(
             status.success(),
-            "git clone dav1d-test-data failed (exit {}). Check network connectivity.",
-            status
+            "git clone dav1d-test-data failed (exit {status}). Check network connectivity."
         );
+
+        // Someone else may have won while we cloned; that is fine and expected.
+        if std::fs::rename(&staging, &dir).is_err() {
+            let _ = std::fs::remove_dir_all(&staging);
+            assert!(
+                dir.join("8-bit/data/meson.build").exists(),
+                "could not move the clone into {} and no other process supplied it",
+                dir.display()
+            );
+        }
     });
 
     assert!(


### PR DESCRIPTION
The corpus decode-parity gate **could not report a failure**, and had **no tile-threading coverage**. Both fixed.

## What was wrong

**1. `continue-on-error: true` on BOTH the download and the test step.** Together they made the gate unable to fail in any circumstance — a failed download fell through to a run with no vectors, and that run could not fail either. The justification comment said aarch64 "is not yet fully conformant (mc_arm 8-tap OOB on inter frames)". That is **stale**: the corpus passes on aarch64 and x86_64 today (#455 campaign; 302/766 at its start).

**2. `Settings::default()` is `threads: 1`** (`src/managed.rs:196`), so the only leg that ran was single-threaded. CI had no tile-threaded decode coverage at all — which is why the x86_64 t=8 deblock read/write race (#494/#497) reached `main`: a V-window using a constant `tap_after = 7` instead of the mask-selected reach, reading 3 rows past its superblock row. A t=8 corpus leg is the cheapest thing that would have caught it.

This is the **ninth** gate in this repo found reporting green (or nothing) while testing nothing, after `wide_exclusion` routed off the wide path by `SHARDS_SERIAL=1`, `decode_permutations` pinned to a platform where the code does not exist, `md5_inventory` defaulting to `--threads 1`, the `guard_move_release` control arm at 0 refusals, `disjoint-mut CI` path-filtering out both Miri legs, `ci.yml`'s base-branch filter on #501, and — in the sibling repo today — a tier test whose oracle was the function under test.

## What changed

- Both `continue-on-error`s removed.
- The download is **retried** (3 attempts, backoff) rather than ignored: a network flake should cost a retry, not silently disarm the conformance suite.
- **New leg**: the same 766 vectors at `RAV1D_MD5_THREADS=8`. Same expected MD5s — a decode that changes with the worker count is a threading bug, and this is the gate that says so.
- `tests/decode_md5_verify.rs` reads `RAV1D_MD5_THREADS`, **defaulting to 1**, so unset changes nothing and the existing leg is untouched. It is an env var read by the test rather than a second `#[test]` because the decision must be visible in the chain (workflow → invocation), per the project's rule against skip/spread decisions buried in a test body. A malformed value is a **hard panic**, not a silent fallback to 1 — a typo in a CI file must not quietly downgrade the gate it exists to complement.

## Verified (macOS aarch64, full corpus present)

Checked that the corpus was actually resident rather than the 14-test shape a missing corpus produces — a gate I cannot prove is live is the thing this PR exists to fix.

| run | result |
|---|---|
| t=1 (unset) | TOTAL **766 passed, 0 failed** |
| t=8 (`RAV1D_MD5_THREADS=8`) | TOTAL **766 passed, 0 failed** |
| `RAV1D_MD5_THREADS=oops` | panics `is not a u32: invalid digit found in string` — hard-error path live |

## Risk, stated plainly

Removing `continue-on-error` means this leg can now turn CI red. That is the point. If it goes red on a Linux runner, that is a real finding about an environment the local aarch64 box does not cover — not a reason to put the flag back.

## Noted, not fixed

2 vectors in `8-bit/features` skip **silently inside the harness** (additional to the 766, not part of it). A runtime self-skip is the pattern the project bans; it wants a caller-visible switch. Out of scope here.