### PR TITLE
test: verify frame and tile concurrency after the ARM film-grain fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,9 @@ jobs:
       - name: Film grain with threading and debug extent checks (#526)
         run: cargo nextest run --profile ci --test filmgrain_threads --test-threads 1
         timeout-minutes: 10
+      - name: Film grain with parallel frame contexts and tile workers (#526)
+        run: cargo nextest run --profile ci --features unchecked --lib --test filmgrain_threads -E 'binary(filmgrain_threads) | test(parallel_frame_tile_contexts)' --test-threads 1 --success-output immediate
+        timeout-minutes: 10
       - name: Run conformance (all vectors × all CPU tiers)
         # Each per-tier test runs in its own process, so switching the global
         # CPU-flags mask can't race across tests (no --test-threads=1 needed).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -912,6 +912,12 @@ Default checked builds clamp `n_fc` to 1 in `src/lib.rs::get_num_threads`,
 so the 1/2/4/8-thread corpus run validates tile/grain worker concurrency,
 not concurrent frame contexts. The latter requires `unchecked` and was not
 validated in this run. Throughput impact was not measured.
+Follow-up concurrency validation on 2026-09-06 (`6115e06b`) passes with
+`unchecked`: 117 film-grain runs using 2/4 frame contexts, three independent
+decoders, and a 32-tile stream at eight workers and 1/2/4 frame contexts.
+See [FILMGRAIN_CONCURRENCY.md](docs/FILMGRAIN_CONCURRENCY.md) for the matrix,
+input-backpressure contract, liveness checks, and limits. Checked frame
+threading remains disabled; the earlier paragraph describes the initial run.
 The original downstream zenpipe AVIF was not identified or rerun here.
 Additional checks on Apple ARM: 116 dev-profile unit/committed-vector/crash
 tests passed (8 pre-existing ignored tests); six focused release tests passed,

--- a/docs/FILMGRAIN_CONCURRENCY.md
+++ b/docs/FILMGRAIN_CONCURRENCY.md
@@ -1,0 +1,51 @@
+# Film-grain frame and tile concurrency
+
+Verified on Apple ARM on 2026-09-06, test commit `6115e06b`, based on
+`e73811f5`. This extends the regression coverage for
+[issue #526](https://github.com/imazen/rav1d-safe/issues/526); its ARM row-borrow
+and worker-panic cleanup fixes were already on `main`.
+
+Run `just test-filmgrain-concurrency`. It runs the selected tests twice in the
+dev profile, first checked and then with `unchecked`, with one nextest test at
+a time. The tests themselves create the worker/decoder concurrency.
+
+| Configuration | Input and checks | Result |
+|---|---|---|
+| Checked tile-only | 13 film-grain vectors, 1/2/4/8 workers, explicit frame delay 1; reference MD5s | Pass |
+| Unchecked tile-only | Same corpus and thread grid | Pass |
+| Unchecked frame pipeline | 13 vectors, including 2 multi-frame sequences; (workers, frame contexts) = (4,2), (8,2), (8,4), three repetitions per cell | 117 runs pass; exact reference MD5 and serial frame count |
+| Independent decoders | Three simultaneous four-worker decoders, all 13 vectors; checked uses delay 1, unchecked mixes delays 1 and 2 | Pass |
+| Multiple tiles and frame contexts | Committed 1024x1024 stream with 4x8 tiles, repeated 12 times; eight workers with 1/2/4 frame contexts | All output frame hashes match serial; actual context and worker counts asserted |
+
+The final frame-pipeline run reported 165 packet submissions whose output was
+deferred. The test also requires multi-frame input, so a corpus made entirely
+of synchronous stills cannot satisfy its liveness assertions. The 32-tile
+fixture independently asserts that its decoded frame header has multiple tiles.
+These establish the exercised configurations and asynchronous output behavior;
+no scheduler trace or measurement of peak simultaneously executing tasks was
+collected.
+
+The complete selected matrix passed five tests in the checked build and six in
+the unchecked build. Clippy for the library and film-grain integration target
+passed in both configurations. Filtering excludes unrelated library tests;
+none of the selected tests is ignored.
+
+## Input backpressure
+
+`rav1d_send_data` returns `EAGAIN` before consuming new input when a prior packet
+still has pending bytes. `Decoder::decode` exposes that as `NeedMoreData`.
+The test caller must retain the rejected packet, call `get_frame`, account for
+any returned frame, and retry the same packet. `get_frame` can return `None`
+after moving pending input into a frame context; that does not mean the new
+packet was consumed. The test uses a deadline to catch a stalled retry loop.
+It drains with `flush` only at end of input and verifies frame counts and hashes.
+
+## Limits
+
+The checked build still forces one frame context per decoder in
+`src/lib.rs::get_num_threads`. Multiple frame contexts require `unchecked`;
+this PR does not enable checked frame threading or change public APIs. The
+film-grain corpus covers 8/10-bit streams and all three chroma layouts. The
+separate 32-tile fixture covers repeated keyframes; the grain corpus supplies
+the multi-frame sequences. Throughput was not measured, and the optional
+assembly feature was not part of this matrix.

--- a/justfile
+++ b/justfile
@@ -333,3 +333,8 @@ arm-tiers-macos:
     mkdir -p "$HOME/tmp"
     CARGO_BUILD_JOBS=4 RAYON_NUM_THREADS=4 OMP_NUM_THREADS=4 TMPDIR="$HOME/tmp" nice -n 19 cargo bench --locked -p rav1d-safe --bench tier_isolation -- --format=llm > "$HOME/tmp/rav1d-arm-tiers.log" 2>&1
 
+
+# #526: actual frame contexts plus a 32-tile stream, and concurrent decoders.
+test-filmgrain-concurrency:
+    CARGO_BUILD_JOBS=2 nice -n 19 cargo nextest run --lib --test filmgrain_threads -E 'binary(filmgrain_threads) | test(parallel_frame_tile_contexts)' --test-threads 1 --success-output immediate
+    CARGO_BUILD_JOBS=2 nice -n 19 cargo nextest run --features unchecked --lib --test filmgrain_threads -E 'binary(filmgrain_threads) | test(parallel_frame_tile_contexts)' --test-threads 1 --success-output immediate

--- a/src/managed.rs
+++ b/src/managed.rs
@@ -1461,3 +1461,7 @@ pub fn enabled_features() -> String {
 
     features.join(", ")
 }
+
+#[cfg(test)]
+#[path = "managed/frame_tile_tests.rs"]
+mod frame_tile_tests;

--- a/src/managed/frame_tile_tests.rs
+++ b/src/managed/frame_tile_tests.rs
@@ -1,0 +1,91 @@
+use super::*;
+
+// Committed 1024x1024 still with a 4x8 tile grid.
+const STREAM: &[u8] = include_bytes!("../../tests/crash_vectors/tile_threading_cdef_lpf_race.obu");
+
+fn hash(frame: &Frame) -> String {
+    let mut hash = md5::Context::new();
+    match frame.planes() {
+        Planes::Depth8(p) => {
+            for row in p.y().rows() {
+                hash.consume(row);
+            }
+            for plane in [p.u(), p.v()].into_iter().flatten() {
+                for row in plane.rows() {
+                    hash.consume(row);
+                }
+            }
+        }
+        Planes::Depth16(p) => {
+            for row in p.y().rows() {
+                for px in row {
+                    hash.consume(px.to_le_bytes());
+                }
+            }
+            for plane in [p.u(), p.v()].into_iter().flatten() {
+                for row in plane.rows() {
+                    for px in row {
+                        hash.consume(px.to_le_bytes());
+                    }
+                }
+            }
+        }
+    }
+    format!("{:x}", hash.finalize())
+}
+
+#[test]
+fn parallel_frame_tile_contexts_preserve_frames() {
+    let mut serial = Decoder::new().unwrap();
+    let reference = serial.decode(STREAM).unwrap().expect("single still frame");
+    let header = &reference.inner.frame_hdr.as_ref().unwrap().tiling;
+    eprintln!("fixture tiles={}x{}", header.cols, header.rows);
+    assert!(
+        header.cols as usize * header.rows as usize > 1,
+        "fixture must have multiple tiles"
+    );
+    let reference = hash(&reference);
+    assert_eq!(
+        &STREAM[..2],
+        &[0x12, 0],
+        "temporal delimiter required for repetition"
+    );
+    let mut modes = vec![(8, 1)];
+    if cfg!(feature = "unchecked") {
+        modes.extend([(8, 2), (8, 4)]);
+    }
+    for (threads, max_frame_delay) in modes {
+        let mut settings = Settings::default();
+        settings.threads = threads;
+        settings.max_frame_delay = max_frame_delay;
+        let mut decoder = Decoder::with_settings(settings).unwrap();
+        assert_eq!(decoder.ctx.fc.len(), max_frame_delay as usize);
+        assert_eq!(decoder.ctx.tc.len(), threads as usize);
+        let mut output = Vec::new();
+        for _ in 0..12 {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+            loop {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "input backpressure did not clear"
+                );
+                match decoder.decode(STREAM) {
+                    Ok(frame) => {
+                        output.extend(frame);
+                        break;
+                    }
+                    Err(e) if matches!(e.error(), Error::NeedMoreData) => {
+                        output.extend(decoder.get_frame().unwrap());
+                    }
+                    Err(e) => panic!("decode: {e}"),
+                }
+            }
+        }
+        output.extend(decoder.flush().unwrap());
+        assert_eq!(output.len(), 12, "frame contexts={max_frame_delay}");
+        for frame in &output {
+            assert_eq!(hash(frame), reference, "frame contexts={max_frame_delay}");
+        }
+        eprintln!("workers={threads} frame_contexts={max_frame_delay}: all 12 frame hashes match");
+    }
+}

--- a/tests/filmgrain_threads.rs
+++ b/tests/filmgrain_threads.rs
@@ -198,17 +198,29 @@ fn hash_frame(frame: &Frame, ctx: &mut md5::Context) {
 
 /// Decode every packet and return `(md5, frames, max_height)`.
 fn decode(ivf: &Path, threads: u32, apply_grain: bool) -> Result<(String, usize, usize), String> {
+    let (hash, frames, height, _) = decode_with_delay(ivf, threads, 1, apply_grain)?;
+    Ok((hash, frames, height))
+}
+
+fn decode_with_delay(
+    ivf: &Path,
+    threads: u32,
+    max_frame_delay: u32,
+    apply_grain: bool,
+) -> Result<(String, usize, usize, usize), String> {
     let file = std::fs::File::open(ivf).map_err(|e| format!("open {}: {e}", ivf.display()))?;
     let mut reader = std::io::BufReader::new(file);
     let packets = ivf_parser::parse_all_frames(&mut reader).map_err(|e| format!("ivf: {e}"))?;
 
     let mut settings = Settings::default();
     settings.threads = threads;
+    settings.max_frame_delay = max_frame_delay;
     settings.apply_grain = apply_grain;
     let mut decoder = Decoder::with_settings(settings).map_err(|e| format!("decoder: {e}"))?;
 
     let mut ctx = md5::Context::new();
     let mut n = 0usize;
+    let mut deferred = 0usize;
     let mut max_h = 0usize;
     let note = |frame: &Frame, ctx: &mut md5::Context, n: &mut usize, max_h: &mut usize| {
         let h = match frame.planes() {
@@ -221,16 +233,42 @@ fn decode(ivf: &Path, threads: u32, apply_grain: bool) -> Result<(String, usize,
     };
 
     for p in &packets {
-        match decoder.decode(&p.data) {
-            Ok(Some(frame)) => note(&frame, &mut ctx, &mut n, &mut max_h),
-            Ok(None) => {}
-            Err(e) => return Err(format!("decode packet {n}: {e}")),
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        loop {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "decoder made no progress on input backpressure"
+            );
+            match decoder.decode(&p.data) {
+                Ok(Some(frame)) => {
+                    note(&frame, &mut ctx, &mut n, &mut max_h);
+                    break;
+                }
+                Ok(None) => {
+                    deferred += 1;
+                    break;
+                }
+                Err(e) if matches!(e.error(), rav1d_safe::src::managed::Error::NeedMoreData) => {
+                    // send_data rejected this packet before consuming it.
+                    // Retrieve output from the previous packet, then retry
+                    // the SAME bytes; dropping them would hide frame loss.
+                    if let Some(frame) = decoder
+                        .get_frame()
+                        .map_err(|e| format!("backpressure: {e}"))?
+                    {
+                        note(&frame, &mut ctx, &mut n, &mut max_h);
+                    }
+                    // None can still mean pending input was parsed into a
+                    // frame context. Retry submission before forcing a drain.
+                }
+                Err(e) => return Err(format!("decode packet {n}: {e}")),
+            }
         }
     }
     for frame in decoder.flush().map_err(|e| format!("flush: {e}"))? {
         note(&frame, &mut ctx, &mut n, &mut max_h);
     }
-    Ok((format!("{:x}", ctx.finalize()), n, max_h))
+    Ok((format!("{:x}", ctx.finalize()), n, max_h, deferred))
 }
 
 /// The gate: every film-grain vector must produce the reference MD5 at 1, 2, 4
@@ -315,4 +353,82 @@ fn some_vector_spans_multiple_row_bands() {
          two grain workers can never contend, so the thread test is vacuous"
     );
     eprintln!("tallest grain vector {best_name}: {best} px = {bands} row bands");
+}
+
+/// Frame contexts must actually be enabled; checked builds clamp them to one.
+#[cfg(feature = "unchecked")]
+#[test]
+fn film_grain_frame_and_tile_threads_match_reference() {
+    let vectors = grain_vectors();
+    let mut deferred = 0;
+    let mut multi_frame_vectors = 0;
+    for v in &vectors {
+        let baseline = decode(&v.ivf, 1, true).expect("serial reference");
+        assert_eq!(baseline.0, v.expected_md5, "serial {}", v.name);
+        multi_frame_vectors += usize::from(baseline.1 > 1);
+        for (threads, delay) in [(4, 2), (8, 2), (8, 4)] {
+            for rep in 0..3 {
+                let result = decode_with_delay(&v.ivf, threads, delay, true).unwrap_or_else(|e| {
+                    panic!("{} t={threads} delay={delay} rep={rep}: {e}", v.name)
+                });
+                assert_eq!(
+                    result.0, v.expected_md5,
+                    "{} t={threads} delay={delay} rep={rep}",
+                    v.name
+                );
+                assert_eq!(result.1, baseline.1, "lost/duplicated frames: {}", v.name);
+                deferred += result.3;
+            }
+        }
+    }
+    assert!(
+        multi_frame_vectors > 0,
+        "no multi-frame input exercised the pipeline"
+    );
+    assert!(deferred > 0, "frame decoding never deferred output");
+    eprintln!(
+        "{} vectors, {} multi-frame vectors, {} deferred packet outputs, {} threaded decode runs",
+        vectors.len(),
+        multi_frame_vectors,
+        deferred,
+        vectors.len() * 9
+    );
+}
+
+/// Separate decoders have separate picture buffers but share dispatch state.
+#[test]
+fn film_grain_independent_decoders_match_reference() {
+    let vectors = grain_vectors();
+    let barrier = std::sync::Barrier::new(3);
+    std::thread::scope(|scope| {
+        let mut workers = Vec::new();
+        for worker in 0..3 {
+            let vectors = &vectors;
+            let barrier = &barrier;
+            workers.push(scope.spawn(move || {
+                // One start barrier: a decode failure must not leave sibling
+                // workers blocked at a later barrier.
+                barrier.wait();
+                for v in vectors {
+                    let delay = if cfg!(feature = "unchecked") && worker != 0 {
+                        2
+                    } else {
+                        1
+                    };
+                    let result = decode_with_delay(&v.ivf, 4, delay, true).unwrap_or_else(|e| {
+                        panic!("{} decoder={worker} delay={delay}: {e}", v.name)
+                    });
+                    assert_eq!(
+                        result.0, v.expected_md5,
+                        "{} decoder={worker} delay={delay}",
+                        v.name
+                    );
+                    assert!(result.1 > 0, "no frames: {}", v.name);
+                }
+            }));
+        }
+        for worker in workers {
+            worker.join().expect("parallel decoder panicked");
+        }
+    });
 }


### PR DESCRIPTION
The ARM film-grain borrow and panic-cleanup fixes for #526 are already on `main`. This PR verifies the concurrency modes that the initial tile-only run did not cover and adds them to CI.

The corpus test now selects tile-only decoding explicitly, checks 2/4 frame contexts with 4/8 workers, and runs three independent decoders together. It retains and retries unaccepted packets after polling pending output. A committed 32-tile stream separately checks the actual worker/frame-context counts and compares every output frame against serial decoding.

Validated on Apple ARM with `just test-filmgrain-concurrency`:

- Checked: five selected tests pass, including tile-only reference MD5s at 1/2/4/8 workers and concurrent decoders.
- Unchecked: six selected tests pass, including 117 film-grain runs across 13 vectors, with exact MD5 and frame-count checks.
- 4x8-tile stream: eight workers, 1/2/4 actual frame contexts, all 12 output frame hashes match serial.
- Library and film-grain integration clippy pass with warnings denied in both configurations; formatting passes.

Checked builds still clamp each decoder to one frame context. Multiple frame contexts are verified with `unchecked`; this PR does not enable checked frame threading or change the public API. No throughput or peak simultaneous-task measurement is claimed. Details: `docs/FILMGRAIN_CONCURRENCY.md`.

Fixes #526.
