### PR TITLE
Fix guard-extent release gate after feature rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,7 +516,9 @@ jobs:
           # Caller-side skip control, per the no-graceful-skips rule: the test
           # body never decides to skip the corpus leg, this line does.
           RAV1D_EXTENT_GATE_CORPUS: "1"
-        run: cargo test --release --features __probe_sites --test guard_extent_budget -- --nocapture
+        run: |
+          cargo test --release --features __probe_sites --test guard_extent_budget -- --list | grep -Fx 'picture_reservations_stay_inside_the_measured_ceiling: test'
+          cargo test --release --features __probe_sites --test guard_extent_budget -- --nocapture
         timeout-minutes: 30
 
   # ==========================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Migration notes and validation history are in
 [the 0.6.0 release record](docs/RELEASE_0_6_0.md).
 
 ### Release preparation
+- Keep the guard-extent corpus test enabled after the `__probe_sites` rename;
+  CI verifies the intended test is present before executing the gate.
 - Refresh workspace dependency requirements and lockfile, including cc 1.4.5,
   zenbench 0.1.9, tango-bench 0.8.0, zenavif-parse 0.6.2 and Criterion 0.8.2.
   Decoder development tools need Rust 1.93; library minimums remain unchanged.

--- a/docs/RELEASE_0_6_0.md
+++ b/docs/RELEASE_0_6_0.md
@@ -203,3 +203,12 @@ bytes and safe SIMD Rust for 3,734,957. These are source archives, not linked
 binary sizes or dependency downloads. [Sizes, hashes and largest files](../release/0.6.0/package-sizes.json)
 identify these tested artifacts; subsequent documentation edits change archive
 identity and require final packaging again at the release revision.
+
+## Final gate correction
+
+The local release run found the guard-extent test still gated by the old
+`probe-sites` name. The CI job had therefore reported success with zero tests.
+Its cfg now uses `__probe_sites`; CI first checks for the exact test name to
+prevent recurrence. The restored test passes with `RAV1D_EXTENT_GATE_CORPUS=1`
+over the committed vectors and dav1d corpus. Earlier green results for this
+job after the feature rename were vacuous and are not validation evidence.

--- a/tests/guard_extent_budget.rs
+++ b/tests/guard_extent_budget.rs
@@ -19,7 +19,7 @@
 //! `include/dav1d/picture.rs::note_pic_extent`, at the single funnel every
 //! tracked picture-plane reservation passes through. It is compiled under
 //! `debug_assertions` (so plain `cargo test` catches a widening) or under
-//! `--features probe-sites` (so this gate can run it in RELEASE, over real
+//! `--features __probe_sites` (so this gate can run it in RELEASE, over real
 //! decodes, at the speed that needs). The default release build has no
 //! counter, no atomic load and no branch there.
 //!
@@ -42,15 +42,15 @@
 //! # Running
 //!
 //! ```text
-//! cargo test --release --features probe-sites --test guard_extent_budget -- --nocapture
-//! RAV1D_EXTENT_GATE_CORPUS=1 cargo test --release --features probe-sites \
+//! cargo test --release --features __probe_sites --test guard_extent_budget -- --nocapture
+//! RAV1D_EXTENT_GATE_CORPUS=1 cargo test --release --features __probe_sites \
 //!     --test guard_extent_budget -- --nocapture     # + the dav1d corpus leg
 //! ```
 //!
 //! The corpus leg is opt-in **from the caller** (CI sets it), never decided
 //! inside the test body.
 
-#![cfg(feature = "probe-sites")]
+#![cfg(feature = "__probe_sites")]
 
 use rav1d_safe::include::dav1d::picture::{
     TILE_THREADED_PIC_EXTENT_MAX_BYTES, extent_budget, pic_extent_ceiling_const,
@@ -255,7 +255,7 @@ fn picture_reservations_stay_inside_the_measured_ceiling() {
     //
     // Redundant with the in-decoder panic (which fires first, inside whichever
     // worker took the guard), and deliberately so: this restates it as a test
-    // assertion so a `--features probe-sites` run that somehow swallowed the
+    // assertion so a `--features __probe_sites` run that somehow swallowed the
     // panic still reports.
     assert!(
         over.is_empty(),


### PR DESCRIPTION
The feature rename left the guard-extent test gated by `probe-sites` while CI enabled `__probe_sites`, so the job passed without running a test. Match the new feature name and require the exact test to appear in the list before CI executes it.

Validated locally with the committed vectors and full dav1d corpus: one test passed, covering 533,039,274 checked reservations and 1,734 frames. This corrects a release-validation gap; decoder code is unchanged. The release record explicitly retracts the earlier vacuous CI results.
