### PR TITLE
fix: itx_wasm 4x4 kernels wrote transposed output

### DIFF
--- a/src/safe_simd/itx_wasm.rs
+++ b/src/safe_simd/itx_wasm.rs
@@ -183,8 +183,12 @@ fn inv_txfm_add_dct_dct_4x4_8bpc(
     // Column transform: DCT4 across all 4 columns
     let (f0, f1, f2, f3) = dct4_4rows(tc0, tc1, tc2, tc3, col_clip_min, col_clip_max);
 
-    // Transpose back to row-major for output
-    let (out0, out1, out2, out3) = transpose_4x4(f0, f1, f2, f3);
+    // fJ already holds ROW J of the final matrix: the column pass consumes
+    // lanes grouped as columns, so its J-th outputs across lanes form row J.
+    // Do NOT transpose again here: a second transpose would write columns as
+    // rows (pixelated top-band corruption on real content; only symmetric /
+    // DC-only blocks were unaffected).
+    let (out0, out1, out2, out3) = (f0, f1, f2, f3);
 
     // Scale: (val + 8) >> 4
     let rnd = i32x4_splat(8);
@@ -360,8 +364,9 @@ fn inv_txfm_add_dct_dct_4x4_16bpc(
     // Column transform
     let (f0, f1, f2, f3) = dct4_4rows(tc0, tc1, tc2, tc3, col_clip_min, col_clip_max);
 
-    // Transpose back
-    let (out0, out1, out2, out3) = transpose_4x4(f0, f1, f2, f3);
+    // fJ already holds ROW J of the final matrix (see the 8bpc kernel note).
+    // A second transpose here would write columns as rows.
+    let (out0, out1, out2, out3) = (f0, f1, f2, f3);
 
     // Scale: (val + 8) >> 4
     let rnd = i32x4_splat(8);


### PR DESCRIPTION
Related details: https://github.com/mlm-games/Miniter/issues/30

Ai comment desc: The column pass consumes lanes grouped as columns, so its J-th outputs across lanes already form row J of the final matrix. The extra trailing transpose_4x4 wrote columns as rows, corrupting every 4x4 DCT_DCT block with asymmetric content on wasm32 (other targets never run these kernels). DC-only and symmetric blocks were unaffected, which is why flat/single-color content decoded fine.

Verified byte-identical vs native scalar output on 64x64, 320x240 and 1920x1080 inputs, and vs dav1d on the 1080p repro.